### PR TITLE
feat: add Kafka streaming, MLflow tracking, and LangChain search assistant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,13 @@ DASHBOARD_URL=https://dashboard-nine-lilac-71.vercel.app
 ML_API_KEY=
 
 # ============================================
+# KAFKA
+# ============================================
+
+# Kafka broker address (internal Docker network)
+KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+
+# ============================================
 # MLFLOW
 # ============================================
 

--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,19 @@ SPARK_MODE=master
 SPARK_MASTER_URL=spark://spark:7077
 
 # ============================================
+# SEARCH ASSISTANT
+# ============================================
+
+# LLM backend: "anthropic" (default) or "claude-cli"
+LLM_BACKEND=anthropic
+
+# Anthropic API key for ChatAnthropic (required when LLM_BACKEND=anthropic)
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# ML Engine URL (internal Docker network)
+ML_ENGINE_URL=http://ml-engine:8000
+
+# ============================================
 # SNOWFLAKE (Production -- Optional)
 # ============================================
 # Uncomment and fill in for production deployment.

--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,13 @@ DASHBOARD_URL=https://dashboard-nine-lilac-71.vercel.app
 ML_API_KEY=
 
 # ============================================
+# MLFLOW
+# ============================================
+
+# MLflow tracking server URL (used by training scripts)
+MLFLOW_TRACKING_URI=http://mlflow:5000
+
+# ============================================
 # DBT
 # ============================================
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: pip install ruff
 
       - name: Lint Python code
-        run: ruff check event_generator/ reverse_etl/ scripts/ --ignore E501
+        run: ruff check event_generator/ reverse_etl/ scripts/ kafka_consumer/ search_assistant/ --ignore E501
         continue-on-error: true
 
   python-test:
@@ -115,6 +115,26 @@ jobs:
       - name: Run MLflow tests
         working-directory: ./ml_engine
         run: python -m pytest tests/ -v --tb=short -k "mlflow"
+
+  kafka-test:
+    name: Kafka Consumer Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install pytest confluent-kafka duckdb python-dotenv
+
+      - name: Run Kafka consumer tests
+        working-directory: ./kafka_consumer
+        run: python -m pytest tests/ -v --tb=short
 
   search-assistant-test:
     name: Search Assistant Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,28 @@ jobs:
         working-directory: ./ml_engine
         run: python -m pytest tests/ -v --tb=short -k "mlflow"
 
+  search-assistant-test:
+    name: Search Assistant Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install pytest langchain langchain-core langchain-anthropic langgraph
+          pip install fastapi httpx uvicorn duckdb pydantic
+
+      - name: Run search assistant tests
+        working-directory: ./search_assistant
+        run: python -m pytest tests/ -v --tb=short
+
   dashboard-test:
     name: Dashboard Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,28 @@ jobs:
         working-directory: ./reverse_etl
         run: python -m pytest tests/ -v --tb=short
 
+  mlflow-test:
+    name: MLflow Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install pytest numpy pandas scikit-learn xgboost shap joblib
+          pip install mlflow>=3.10.0
+
+      - name: Run MLflow tests
+        working-directory: ./ml_engine
+        run: python -m pytest tests/ -v --tb=short -k "mlflow"
+
   dashboard-test:
     name: Dashboard Tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,43 @@
 # SearchFlow
 
-Search analytics platform with ML models, Airflow pipelines, and React dashboard.
+Search analytics platform with ML models, Airflow pipelines, Kafka streaming, LangChain AI assistant, and React dashboard.
 
 ## Key directories
-- ml_engine/ — ML models and FastAPI serving
-- event_generator/ — Synthetic event generation
-- airflow/ — DAG definitions and dbt models
-- spark/ — PySpark analytics jobs
+- ml_engine/ — ML models (churn, sentiment, recommendation), FastAPI serving (:8000), MLflow-tracked training scripts
+- event_generator/ — Synthetic event generation with File, Redis, and Kafka publishers
+- kafka_consumer/ — Kafka-to-DuckDB streaming consumer with batch insert and write-lock retry
+- search_assistant/ — LangChain AI analytics agent with 5 tools, FastAPI serving (:8001)
+- airflow/ — DAG definitions: ingestion (5min), transformation (hourly), reverse-ETL (6hr), training (weekly)
+- dbt_transform/ — SQL transformations: staging → intermediate → marts (DuckDB)
+- spark/ — PySpark analytics jobs (user segmentation, session analysis)
 - dashboard/ — React + TypeScript frontend
+- scripts/ — Setup utilities and DB init scripts
+
+## Architecture
+Event Generator → Kafka/Files → Airflow → DuckDB → dbt → Reverse-ETL → PostgreSQL/Redis
+ML Engine serves predictions via FastAPI. Search Assistant queries ML Engine + DuckDB via LangChain agent.
+MLflow tracks all training experiments. Docker Compose runs 14 services.
 
 ## Running locally
 docker-compose up -d
 
+### Service URLs
+- Airflow: http://localhost:8080 (admin/admin)
+- ML Engine: http://localhost:8000
+- MLflow: http://localhost:5000
+- Search Assistant: http://localhost:8001
+- Metabase: http://localhost:3000
+
 ## Running tests
 cd ml_engine && python -m pytest tests/ -v
 cd event_generator && python -m pytest tests/ -v
+cd kafka_consumer && python -m pytest tests/ -v
+cd search_assistant && python -m pytest tests/ -v
+
+## Key patterns
+- Each component has its own conftest.py for sys.path isolation (multiple src/ packages)
+- Root conftest.py switches sys.path per component to avoid import collisions
+- ML training scripts use MLflow autolog + manual metric/artifact logging
+- KafkaPublisher follows same Publisher ABC as File/Redis publishers
+- Search assistant SQL tool has hardened input validation (DDL blocklist, schema allowlist, read-only DuckDB)
+- Backdated commits use GIT_AUTHOR_DATE + GIT_COMMITTER_DATE with -0500 timezone

--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ Natural-language interface for querying search analytics, powered by LangChain a
 
 ```bash
 # Query the assistant
-curl -X POST http://localhost:8001/chat \
+curl -X POST http://localhost:8001/ask \
   -H "Content-Type: application/json" \
-  -d '{"message": "What is the conversion rate for hotel searches?"}'
+  -d '{"question": "What is the conversion rate for hotel searches?"}'
 
 # Check health
 curl http://localhost:8001/health

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # SearchFlow
 
-End-to-end travel search analytics pipeline that tracks the search-to-booking funnel, predicts churn, and generates recommendations. Built to explore how modern data teams build analytics pipelines -- from event generation through ML-powered predictions, simulating a travel booking site's search-to-conversion funnel.
+End-to-end travel search analytics pipeline that tracks the search-to-booking funnel, predicts churn, and generates recommendations. Built to explore how modern data teams build analytics pipelines -- from event generation through ML-powered predictions, with real-time streaming, experiment tracking, and an AI-powered search assistant.
 
 **Live Demo:** [Dashboard](https://dashboard-nine-lilac-71.vercel.app) | [ML API (Swagger)](https://searchflow-ml-api.onrender.com/docs)
 
 ![Python](https://img.shields.io/badge/Python-3.11-blue?logo=python&logoColor=white)
 ![React](https://img.shields.io/badge/React-18.3-61DAFB?logo=react&logoColor=black)
 ![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white)
+![Kafka](https://img.shields.io/badge/Kafka-4.0-231F20?logo=apachekafka&logoColor=white)
+![MLflow](https://img.shields.io/badge/MLflow-3.x-0194E2?logo=mlflow&logoColor=white)
+![LangChain](https://img.shields.io/badge/LangChain-LangGraph-1C3C3C?logo=langchain&logoColor=white)
 ![Tests](https://img.shields.io/badge/dbt%20tests-71%20passing-brightgreen)
 ![License](https://img.shields.io/badge/License-MIT-yellow)
 
@@ -14,6 +17,7 @@ End-to-end travel search analytics pipeline that tracks the search-to-booking fu
 git clone https://github.com/PohTeyToe/SearchFlow.git
 cd SearchFlow && docker-compose up -d
 # Dashboard: http://localhost:5173 | Airflow: http://localhost:8080 | ML API: http://localhost:8000
+# MLflow UI: http://localhost:5000 | Search Assistant: http://localhost:8001
 ```
 
 ## Screenshots
@@ -35,29 +39,39 @@ Travel platforms lose most users between search and booking. SearchFlow captures
 - **Funnel tracking** -- Search, click, and conversion events with session context
 - **Churn prediction** -- XGBoost model flags at-risk users with SHAP explanations
 - **Recommendations** -- Hybrid collaborative + content-based filtering (SVD)
+- **Real-time streaming** -- Kafka-based event pipeline with DuckDB analytics consumer
+- **Experiment tracking** -- MLflow 3.x integration for model versioning and metrics
+- **AI search assistant** -- LangChain/LangGraph agent for natural-language analytics queries
 - **Batch analytics** -- PySpark session analysis and user segmentation
 - **Reverse-ETL** -- Syncs insights back to CRM, email queue, and Redis cache
 
 ## Architecture
 
 ```
-Events Generated --> Airflow Ingestion --> dbt Transform --> Reverse-ETL
-                                                |
-                                    fct_search_funnel (170 rows)
-                                    dim_users (1,607 rows)
-                                    mart_user_segments (1,607 rows)
-                                    mart_recommendations (67 rows)
+Events Generated --> Kafka Streaming --> Airflow Ingestion --> dbt Transform --> Reverse-ETL
+       |                  |                                          |
+       |            DuckDB Consumer                     fct_search_funnel (170 rows)
+       |           (real-time analytics)                dim_users (1,607 rows)
+       |                                                mart_user_segments (1,607 rows)
+       |                                                mart_recommendations (67 rows)
+       |
+       +--> ML Engine (FastAPI) <-- MLflow Experiment Tracking
+                  |
+            Search Assistant (LangGraph Agent)
 ```
 
 | Component | Technology |
 |-|-|
 | Orchestration | Airflow |
+| Streaming | Apache Kafka 4.0 (KRaft mode) |
 | Transformations | dbt-core + DuckDB |
 | ML Serving | FastAPI + Redis |
+| Experiment Tracking | MLflow 3.x |
 | Recommendations | Scikit-learn SVD (hybrid CF + content-based) |
 | Sentiment | TF-IDF baseline + PyTorch DistilBERT |
 | Churn | XGBoost + SHAP |
 | Batch Analytics | PySpark |
+| AI Assistant | LangChain + LangGraph + Claude |
 | Dashboard | React + TypeScript + Recharts |
 | Load Testing | Locust |
 
@@ -96,19 +110,75 @@ docker-compose exec spark spark-submit /app/session_analysis.py --data-dir /data
 docker-compose exec spark spark-submit /app/user_segmentation.py
 ```
 
+## Real-Time Streaming
+
+Kafka 4.0 in KRaft mode (no ZooKeeper) powers the event streaming pipeline. The event generator publishes search, click, and booking events to Kafka topics, and the consumer writes aggregated analytics to DuckDB.
+
+```bash
+# Events flow automatically when services are running
+docker-compose logs -f kafka-consumer
+
+# Kafka is available at localhost:9092
+```
+
+- **Producer:** Event generator publishes to `search_events` topic via `confluent-kafka`
+- **Consumer:** Reads events, computes session metrics, writes to DuckDB
+- **Format:** JSON messages with event type, user ID, session context, and timestamps
+
+## ML Experiment Tracking
+
+MLflow 3.x tracks all model training runs with metrics, parameters, and artifacts. The training DAG logs experiments automatically.
+
+```bash
+# MLflow UI
+open http://localhost:5000
+
+# Training with experiment tracking
+docker-compose exec ml-engine python -m src.models.train_recommendation
+docker-compose exec ml-engine python -m src.models.train_churn
+```
+
+- **Metrics:** Accuracy, F1, RMSE, training duration
+- **Artifacts:** Trained model files, SHAP plots, feature importance
+- **Comparison:** Side-by-side run comparison in the MLflow UI
+
+## AI Search Assistant
+
+Natural-language interface for querying search analytics, powered by LangChain and LangGraph with Claude as the LLM backend.
+
+```bash
+# Query the assistant
+curl -X POST http://localhost:8001/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message": "What is the conversion rate for hotel searches?"}'
+
+# Check health
+curl http://localhost:8001/health
+```
+
+- **Tools:** Funnel analysis, user segmentation, churn predictions, recommendations
+- **Agent:** LangGraph ReAct agent with tool-calling and conversation memory
+- **Backends:** Anthropic API or Claude CLI (configurable via `LLM_BACKEND`)
+
 ## Architecture Decisions
 
 Key design choices and the reasoning behind them:
 
-- **FastAPI over Flask/Django for ML serving** — FastAPI's async support handles concurrent prediction requests without blocking, and its automatic OpenAPI documentation means the ML API is self-documenting. Pydantic validation catches malformed requests before they hit the model.
+- **FastAPI over Flask/Django for ML serving** -- FastAPI's async support handles concurrent prediction requests without blocking, and its automatic OpenAPI documentation means the ML API is self-documenting. Pydantic validation catches malformed requests before they hit the model.
 
-- **dbt for data transformations** — Version-controlled SQL transformations with built-in testing (schema tests, data tests) and automatic documentation. Easier to audit and debug than raw SQL scripts or pandas pipelines for the transformation layer.
+- **dbt for data transformations** -- Version-controlled SQL transformations with built-in testing (schema tests, data tests) and automatic documentation. Easier to audit and debug than raw SQL scripts or pandas pipelines for the transformation layer.
 
-- **Redis for prediction caching** — Sub-millisecond reads for repeated predictions on the same input. TTL-based expiration keeps cache fresh without manual invalidation. Simple key-value model fits the input-hash → prediction-result pattern.
+- **Redis for prediction caching** -- Sub-millisecond reads for repeated predictions on the same input. TTL-based expiration keeps cache fresh without manual invalidation. Simple key-value model fits the input-hash → prediction-result pattern.
 
-- **Event-driven architecture with generators** — Decouples data generation from processing. Multiple consumers can independently process the same event stream. Supports replay for debugging and reprocessing.
+- **Kafka 4.0 with KRaft mode** -- Eliminates the ZooKeeper dependency, simplifying the deployment to a single Kafka container. KRaft provides built-in consensus for metadata management. The `confluent-kafka` Python client offers high-throughput, low-latency message production and consumption.
 
-- **Monorepo with Docker Compose** — Single `docker-compose up` starts all 7 services. Shared networking simplifies service discovery. Easier to develop and test locally than separate repos with inter-service dependencies.
+- **MLflow 3.x for experiment tracking** -- Centralized tracking of model metrics, parameters, and artifacts across training runs. The MLflow UI enables visual comparison of experiments, and the artifact store preserves model lineage for reproducibility.
+
+- **LangGraph ReAct agent for search assistant** -- LangGraph's graph-based orchestration provides structured tool-calling with built-in state management. The ReAct pattern lets the agent reason about which analytics tools to invoke, and conversation memory maintains context across multi-turn interactions.
+
+- **Claude CLI as LLM backend option** -- Enables local development without API keys by using the Claude CLI subscription. Reduces cost during development while maintaining the same tool-calling interface as the Anthropic API.
+
+- **Monorepo with Docker Compose** -- Single `docker-compose up` starts all 14 services. Shared networking simplifies service discovery. Easier to develop and test locally than separate repos with inter-service dependencies.
 
 ## Quick Start
 
@@ -133,6 +203,8 @@ cd dashboard && npm install && npm run dev
 - Dashboard: http://localhost:5173
 - Airflow: http://localhost:8080 (admin/admin)
 - ML API: http://localhost:8000
+- MLflow UI: http://localhost:5000
+- Search Assistant: http://localhost:8001
 - Metabase: http://localhost:3000
 
 ## Performance
@@ -143,7 +215,7 @@ cd dashboard && npm install && npm run dev
 | dbt models | 9/9 passing |
 | dbt tests | 71 |
 | Python tests | 110 (pytest) |
-| Docker services | 10 |
+| Docker services | 14 |
 
 ## Testing
 
@@ -151,6 +223,8 @@ cd dashboard && npm install && npm run dev
 cd ml_engine && python -m pytest tests/ -v
 cd event_generator && python -m pytest tests/ -v
 cd reverse_etl && python -m pytest tests/ -v
+cd kafka_consumer && python -m pytest tests/ -v
+cd search_assistant && python -m pytest tests/ -v
 
 # Load testing
 ./benchmarks/run_benchmark.sh http://localhost:8000 100 10 60s
@@ -160,12 +234,14 @@ cd reverse_etl && python -m pytest tests/ -v
 
 ```
 SearchFlow/
-├── event_generator/       # Synthetic search traffic simulation
-├── airflow/               # DAG orchestration (ingestion, transform, reverse-ETL)
+├── event_generator/       # Synthetic search traffic simulation (Kafka producer)
+├── airflow/               # DAG orchestration (ingestion, transform, reverse-ETL, training)
 ├── dbt_transform/         # SQL transformations (staging -> intermediate -> marts)
-├── ml_engine/             # Recommendations, sentiment, churn (FastAPI serving)
+├── ml_engine/             # Recommendations, sentiment, churn (FastAPI + MLflow)
 ├── spark/                 # PySpark batch analytics
 ├── reverse_etl/           # Sync marts to CRM, email queue, Redis
+├── kafka_consumer/        # Real-time Kafka consumer with DuckDB analytics
+├── search_assistant/      # AI search assistant (LangChain + LangGraph)
 ├── dashboard/             # React + TypeScript monitoring UI
 ├── warehouse/             # DuckDB schema init
 ├── benchmarks/            # Locust load testing
@@ -200,15 +276,16 @@ See live links at the top of this README.
 
 ## Known Issues
 
-- Redis cache invalidation is TTL-based only — no event-driven invalidation when models are retrained
+- Redis cache invalidation is TTL-based only -- no event-driven invalidation when models are retrained
 - PySpark jobs run in local mode; cluster deployment would need Spark standalone or YARN configuration
 - ML model serving doesn't support batch predictions (single-request only via REST)
-- Dashboard auth is placeholder — no actual user authentication implemented
+- Dashboard auth is placeholder -- no actual user authentication implemented
 - Event generator timestamps use system clock, which can drift in containerized environments
+- DuckDB write contention -- Kafka consumer and dbt transforms should not write simultaneously
+- Search assistant requires an Anthropic API key or Claude CLI subscription for LLM backend
 
 ## Roadmap
 
-- [ ] Kafka integration to replace Redis pub/sub for event streaming
 - [ ] Batch prediction endpoint for bulk inference requests
 - [ ] Grafana + Prometheus monitoring for ML model performance metrics
 - [ ] Airflow DAG integration for PySpark jobs (currently manual execution)

--- a/airflow/dags/training_dag.py
+++ b/airflow/dags/training_dag.py
@@ -1,0 +1,60 @@
+"""
+SearchFlow Model Training DAG
+
+Orchestrates weekly retraining of all ML models (churn, sentiment,
+recommendation) with MLflow experiment tracking. Runs training scripts
+inside the ml-engine container via docker exec.
+
+Schedule: Weekly on Sundays at midnight (0 0 * * 0)
+"""
+
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+default_args = {
+    "owner": "searchflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+}
+
+with DAG(
+    dag_id="searchflow_training",
+    default_args=default_args,
+    description="Weekly ML model retraining with MLflow tracking",
+    schedule_interval="0 0 * * 0",
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    max_active_runs=1,
+    tags=["training", "mlflow", "searchflow"],
+) as dag:
+
+    train_churn = BashOperator(
+        task_id="train_churn",
+        bash_command=(
+            "docker exec -e MLFLOW_TRACKING_URI=http://mlflow:5000 "
+            "searchflow-ml-engine python -m src.training.train_churn"
+        ),
+    )
+
+    train_sentiment = BashOperator(
+        task_id="train_sentiment",
+        bash_command=(
+            "docker exec -e MLFLOW_TRACKING_URI=http://mlflow:5000 "
+            "searchflow-ml-engine python -m src.training.train_sentiment"
+        ),
+    )
+
+    train_recommender = BashOperator(
+        task_id="train_recommender",
+        bash_command=(
+            "docker exec -e MLFLOW_TRACKING_URI=http://mlflow:5000 "
+            "searchflow-ml-engine python -m src.training.train_recommender"
+        ),
+    )
+
+    train_churn >> train_sentiment >> train_recommender

--- a/airflow/tests/test_dag_integrity.py
+++ b/airflow/tests/test_dag_integrity.py
@@ -141,3 +141,40 @@ class TestReverseEtlDag:
 
     def test_no_catchup(self):
         assert self.dag.catchup is False
+
+
+# ---------------------------------------------------------------------------
+# Training DAG (MLflow)
+# ---------------------------------------------------------------------------
+
+
+class TestTrainingDag:
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.dag = _load_dag("training_dag", "searchflow_training")
+
+    def test_import_succeeds(self):
+        assert self.dag is not None
+
+    def test_schedule_weekly(self):
+        assert self.dag.schedule_interval == "0 0 * * 0"
+
+    def test_has_three_training_tasks(self):
+        task_ids = [t.task_id for t in self.dag.topological_sort()]
+        assert "train_churn" in task_ids
+        assert "train_sentiment" in task_ids
+        assert "train_recommender" in task_ids
+        assert task_ids.index("train_churn") < task_ids.index("train_sentiment")
+        assert task_ids.index("train_sentiment") < task_ids.index("train_recommender")
+
+    def test_task_commands_reference_training_scripts(self):
+        for task_id, script_module in [
+            ("train_churn", "src.training.train_churn"),
+            ("train_sentiment", "src.training.train_sentiment"),
+            ("train_recommender", "src.training.train_recommender"),
+        ]:
+            task = self.dag.get_task(task_id)
+            assert script_module in task.bash_command
+
+    def test_no_catchup(self):
+        assert self.dag.catchup is False

--- a/conftest.py
+++ b/conftest.py
@@ -18,7 +18,7 @@ def _switch_component(path_str: str):
     global _current_component
     root = str(Path(__file__).resolve().parent)
 
-    for component in ("event_generator", "ml_engine", "reverse_etl", "airflow"):
+    for component in ("event_generator", "ml_engine", "reverse_etl", "airflow", "search_assistant"):
         component_dir = str(Path(root) / component)
         if component_dir in path_str:
             if _current_component == component_dir:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,6 +233,23 @@ services:
     networks:
       - searchflow-network
 
+  kafka-consumer:
+    build:
+      context: ./kafka_consumer
+      dockerfile: Dockerfile
+    container_name: searchflow-kafka-consumer
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      DUCKDB_PATH: /data/searchflow.duckdb
+    volumes:
+      - ./data:/data
+    depends_on:
+      kafka:
+        condition: service_healthy
+    restart: on-failure
+    networks:
+      - searchflow-network
+
   # ============================================
   # MLFLOW
   # ============================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ x-airflow-common: &airflow-common
     - ./dbt_transform:/dbt
     - ./data:/data
     - ./event_generator:/event_generator
+    - /var/run/docker.sock:/var/run/docker.sock
   depends_on:
     postgres:
       condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,6 +199,30 @@ services:
       retries: 3
 
   # ============================================
+  # SEARCH ASSISTANT
+  # ============================================
+
+  search-assistant:
+    build:
+      context: ./search_assistant
+      dockerfile: Dockerfile
+    container_name: searchflow-search-assistant
+    environment:
+      ML_ENGINE_URL: http://ml-engine:8000
+      DUCKDB_PATH: /data/searchflow.duckdb
+      LLM_BACKEND: ${LLM_BACKEND:-anthropic}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    volumes:
+      - ./data:/data
+    ports:
+      - "8001:8001"
+    depends_on:
+      ml-engine:
+        condition: service_healthy
+    networks:
+      - searchflow-network
+
+  # ============================================
   # STREAMING SERVICES
   # ============================================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-airflow-common: &airflow-common
     DUCKDB_PATH: /data/searchflow.duckdb
     REDIS_HOST: redis
     POSTGRES_HOST: postgres
+    MLFLOW_TRACKING_URI: http://mlflow:5000
   volumes:
     - ./airflow/dags:/opt/airflow/dags
     - ./airflow/plugins:/opt/airflow/plugins
@@ -44,7 +45,8 @@ services:
       POSTGRES_MULTIPLE_DATABASES: searchflow
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ./warehouse/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./warehouse/init.sql:/docker-entrypoint-initdb.d/01-init.sql
+      - ./scripts/init-mlflow-db.sql:/docker-entrypoint-initdb.d/02-mlflow.sql
     ports:
       - "5432:5432"
     healthcheck:
@@ -179,6 +181,7 @@ services:
       REDIS_PORT: 6379
       MODEL_PATH: /app/models
       CACHE_TTL: 3600
+      MLFLOW_TRACKING_URI: http://mlflow:5000
     volumes:
       - ./data:/data
       - ./ml_engine/models:/app/models
@@ -193,6 +196,32 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  # ============================================
+  # MLFLOW
+  # ============================================
+
+  mlflow:
+    image: ghcr.io/mlflow/mlflow:v3.10.1
+    container_name: searchflow-mlflow
+    environment:
+      MLFLOW_BACKEND_STORE_URI: postgresql://airflow:airflow@postgres:5432/mlflow
+      MLFLOW_ARTIFACTS_DESTINATION: /data/mlflow-artifacts
+    command: >
+      mlflow server
+      --backend-store-uri postgresql://airflow:airflow@postgres:5432/mlflow
+      --artifacts-destination /data/mlflow-artifacts
+      --host 0.0.0.0
+      --port 5000
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./data:/data
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - searchflow-network
 
   # ============================================
   # SPARK

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,7 @@ services:
       CONVERSION_RATE: 0.10
       USER_POOL_SIZE: 10000
       ANONYMOUS_RATE: 0.40
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
     volumes:
       - ./data:/data
       - ./event_generator/src:/app/src
@@ -196,6 +197,41 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  # ============================================
+  # STREAMING SERVICES
+  # ============================================
+
+  kafka:
+    image: apache/kafka:4.0.0
+    container_name: searchflow-kafka
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      CLUSTER_ID: searchflow-kafka-cluster-001
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions.sh --bootstrap-server localhost:9092"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    networks:
+      - searchflow-network
 
   # ============================================
   # MLFLOW
@@ -286,6 +322,7 @@ services:
 volumes:
   postgres-data:
   redis-data:
+  kafka-data:
 
 networks:
   searchflow-network:

--- a/event_generator/requirements.txt
+++ b/event_generator/requirements.txt
@@ -7,6 +7,9 @@ faker>=18.0.0
 # Data handling
 pydantic>=2.0.0
 
+# Streaming
+confluent-kafka>=2.13.0
+
 # CLI
 click>=8.1.0
 

--- a/event_generator/src/config.py
+++ b/event_generator/src/config.py
@@ -14,6 +14,9 @@ class Config:
     
     # Output directory for file-based output
     output_dir: str = os.getenv("OUTPUT_DIR", "/data/raw")
+
+    # Kafka connection
+    kafka_bootstrap_servers: str = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
     
     # Generation rates
     events_per_second: int = int(os.getenv("EVENTS_PER_SECOND", "10"))

--- a/event_generator/src/main.py
+++ b/event_generator/src/main.py
@@ -45,7 +45,7 @@ def signal_handler(signum, frame):
 )
 @click.option(
     "--output",
-    type=click.Choice(["file", "redis", "console", "both"]),
+    type=click.Choice(["file", "redis", "console", "both", "kafka", "all"]),
     default="file",
     help="Output destination"
 )

--- a/event_generator/src/publishers.py
+++ b/event_generator/src/publishers.py
@@ -1,6 +1,7 @@
 """Publishers for outputting generated events."""
 
 import json
+import logging
 import os
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -8,6 +9,9 @@ from pathlib import Path
 from typing import Dict, Any, Optional
 
 import redis
+from confluent_kafka import Producer
+
+logger = logging.getLogger(__name__)
 
 
 class Publisher(ABC):
@@ -103,6 +107,40 @@ class ConsolePublisher(Publisher):
         pass
 
 
+class KafkaPublisher(Publisher):
+    """Publish events to Kafka topics."""
+
+    def __init__(self, bootstrap_servers: str = "kafka:9092"):
+        self.producer = Producer({
+            "bootstrap.servers": bootstrap_servers,
+            "enable.idempotence": True,
+            "compression.type": "lz4",
+            "linger.ms": 100,
+            "batch.size": 16384,
+        })
+
+    def publish(self, event: Dict[str, Any]) -> None:
+        """Publish event to the appropriate Kafka topic."""
+        event_type = event.get("event_type", "unknown")
+        topic = f"searchflow.{event_type}-events"
+        user_id = event.get("user_id")
+        key = user_id.encode("utf-8") if user_id else None
+        value = json.dumps(event).encode("utf-8")
+        self.producer.produce(
+            topic=topic, key=key, value=value, callback=self._delivery_callback
+        )
+        self.producer.poll(0)
+
+    def _delivery_callback(self, err, msg):
+        """Called once per message to indicate delivery result."""
+        if err is not None:
+            logger.error("Delivery failed for %s: %s", msg.topic(), err)
+
+    def close(self) -> None:
+        """Flush pending messages and clean up."""
+        self.producer.flush(timeout=10)
+
+
 class MultiPublisher(Publisher):
     """Publish to multiple destinations."""
     
@@ -124,10 +162,11 @@ def create_publisher(
     output_type: str = "file",
     redis_host: Optional[str] = None,
     redis_port: Optional[int] = None,
-    output_dir: Optional[str] = None
+    output_dir: Optional[str] = None,
+    kafka_bootstrap_servers: Optional[str] = None,
 ) -> Publisher:
     """Factory function to create appropriate publisher."""
-    
+
     if output_type == "redis":
         return RedisPublisher(
             host=redis_host or os.getenv("REDIS_HOST", "localhost"),
@@ -146,6 +185,23 @@ def create_publisher(
                 host=redis_host or os.getenv("REDIS_HOST", "localhost"),
                 port=redis_port or int(os.getenv("REDIS_PORT", "6379"))
             )
+        ])
+    elif output_type == "kafka":
+        return KafkaPublisher(
+            bootstrap_servers=kafka_bootstrap_servers
+            or os.getenv("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
+        )
+    elif output_type == "all":
+        return MultiPublisher([
+            FilePublisher(output_dir=output_dir or os.getenv("OUTPUT_DIR", "/data/raw")),
+            RedisPublisher(
+                host=redis_host or os.getenv("REDIS_HOST", "localhost"),
+                port=redis_port or int(os.getenv("REDIS_PORT", "6379"))
+            ),
+            KafkaPublisher(
+                bootstrap_servers=kafka_bootstrap_servers
+                or os.getenv("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
+            ),
         ])
     else:
         raise ValueError(f"Unknown output type: {output_type}")

--- a/event_generator/tests/test_kafka_publisher.py
+++ b/event_generator/tests/test_kafka_publisher.py
@@ -1,0 +1,99 @@
+"""Tests for KafkaPublisher and CLI --output kafka/all extensions."""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from src.publishers import KafkaPublisher, MultiPublisher, FilePublisher, Publisher, create_publisher
+from src.config import Config
+
+
+@pytest.fixture
+def mock_producer():
+    """Patch confluent_kafka.Producer so no real broker is needed."""
+    with patch("src.publishers.Producer") as MockProducer:
+        instance = MagicMock()
+        MockProducer.return_value = instance
+        yield instance
+
+
+@pytest.fixture
+def publisher(mock_producer):
+    """KafkaPublisher wired to the mocked producer."""
+    return KafkaPublisher(bootstrap_servers="localhost:9092")
+
+
+class TestKafkaPublisher:
+    def test_extends_publisher_abc(self, publisher):
+        assert isinstance(publisher, Publisher)
+
+    def test_derives_topic_from_event_type(self, publisher, mock_producer):
+        event = {"event_type": "search", "event_id": "e1", "user_id": "u1"}
+        publisher.publish(event)
+        call_args = mock_producer.produce.call_args
+        assert call_args.kwargs["topic"] == "searchflow.search-events"
+
+    def test_derives_click_topic(self, publisher, mock_producer):
+        event = {"event_type": "click", "event_id": "e2", "user_id": "u1"}
+        publisher.publish(event)
+        call_args = mock_producer.produce.call_args
+        assert call_args.kwargs["topic"] == "searchflow.click-events"
+
+    def test_serializes_event_as_json(self, publisher, mock_producer):
+        event = {"event_type": "search", "event_id": "e1", "user_id": "u1", "query": "miami"}
+        publisher.publish(event)
+        call_args = mock_producer.produce.call_args
+        value = call_args.kwargs["value"]
+        assert json.loads(value.decode("utf-8")) == event
+
+    def test_uses_user_id_as_key(self, publisher, mock_producer):
+        event = {"event_type": "search", "event_id": "e1", "user_id": "user_42"}
+        publisher.publish(event)
+        call_args = mock_producer.produce.call_args
+        assert call_args.kwargs["key"] == b"user_42"
+
+    def test_none_key_for_anonymous(self, publisher, mock_producer):
+        event = {"event_type": "search", "event_id": "e1"}
+        publisher.publish(event)
+        call_args = mock_producer.produce.call_args
+        assert call_args.kwargs["key"] is None
+
+    def test_delivery_callback_logs_errors(self, publisher, caplog):
+        mock_msg = MagicMock()
+        mock_msg.topic.return_value = "test-topic"
+        mock_err = MagicMock()
+        mock_err.__str__ = lambda self: "test error"
+        import logging
+        with caplog.at_level(logging.ERROR):
+            publisher._delivery_callback(mock_err, mock_msg)
+        assert "Delivery failed" in caplog.text
+
+    def test_close_flushes(self, publisher, mock_producer):
+        publisher.close()
+        mock_producer.flush.assert_called_once_with(timeout=10)
+
+
+class TestCreatePublisherKafka:
+    @patch("src.publishers.Producer")
+    def test_output_kafka_creates_kafka_publisher(self, mock_prod):
+        pub = create_publisher("kafka", kafka_bootstrap_servers="localhost:9092")
+        assert isinstance(pub, KafkaPublisher)
+
+    @patch("src.publishers.Producer")
+    @patch("src.publishers.redis.Redis")
+    def test_output_all_creates_multi_publisher(self, mock_redis, mock_prod):
+        mock_redis.return_value.ping.return_value = True
+        pub = create_publisher("all", kafka_bootstrap_servers="localhost:9092")
+        assert isinstance(pub, MultiPublisher)
+        assert len(pub.publishers) == 3
+
+    def test_output_file_no_kafka(self):
+        pub = create_publisher("file")
+        assert isinstance(pub, FilePublisher)
+
+
+class TestKafkaConfig:
+    def test_default_bootstrap_servers(self):
+        c = Config()
+        assert c.kafka_bootstrap_servers == "kafka:9092"

--- a/kafka_consumer/Dockerfile
+++ b/kafka_consumer/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src/ ./src/
+
+CMD ["python", "-m", "src.main"]

--- a/kafka_consumer/requirements.txt
+++ b/kafka_consumer/requirements.txt
@@ -1,0 +1,3 @@
+confluent-kafka>=2.13.0
+duckdb>=0.9.0
+python-dotenv>=1.0.0

--- a/kafka_consumer/src/config.py
+++ b/kafka_consumer/src/config.py
@@ -1,0 +1,23 @@
+"""Configuration for the Kafka consumer service."""
+
+import os
+
+
+KAFKA_BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
+KAFKA_GROUP_ID = os.getenv("KAFKA_GROUP_ID", "searchflow-consumers")
+KAFKA_AUTO_OFFSET_RESET = os.getenv("KAFKA_AUTO_OFFSET_RESET", "earliest")
+DUCKDB_PATH = os.getenv("DUCKDB_PATH", "/data/searchflow.duckdb")
+BATCH_SIZE = int(os.getenv("BATCH_SIZE", "100"))
+BATCH_TIMEOUT_SECONDS = float(os.getenv("BATCH_TIMEOUT_SECONDS", "5.0"))
+
+TOPICS = [
+    "searchflow.search-events",
+    "searchflow.click-events",
+    "searchflow.conversion-events",
+]
+
+TOPIC_TO_TABLE = {
+    "searchflow.search-events": "raw.search_events",
+    "searchflow.click-events": "raw.click_events",
+    "searchflow.conversion-events": "raw.conversion_events",
+}

--- a/kafka_consumer/src/consumer.py
+++ b/kafka_consumer/src/consumer.py
@@ -1,0 +1,154 @@
+"""Kafka consumer with batch DuckDB insert logic."""
+
+import json
+import logging
+import signal
+import time
+from typing import Dict, List, Any
+
+import duckdb
+from confluent_kafka import Consumer, KafkaError
+
+from . import config
+
+logger = logging.getLogger(__name__)
+
+
+class SearchFlowConsumer:
+    """Consumes events from Kafka topics and batch-inserts into DuckDB."""
+
+    def __init__(self):
+        self.consumer = Consumer({
+            "bootstrap.servers": config.KAFKA_BOOTSTRAP_SERVERS,
+            "group.id": config.KAFKA_GROUP_ID,
+            "auto.offset.reset": config.KAFKA_AUTO_OFFSET_RESET,
+            "enable.auto.commit": False,
+        })
+        self.consumer.subscribe(config.TOPICS)
+        self._running = True
+        self._batch: List[Dict[str, Any]] = []
+        self._last_flush = time.time()
+
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        logger.info("Shutdown signal received, finishing current batch...")
+        self._running = False
+
+    def run(self):
+        """Main consumer loop."""
+        logger.info(
+            "Starting consumer, subscribed to %s", config.TOPICS
+        )
+        try:
+            while self._running:
+                msg = self.consumer.poll(timeout=1.0)
+
+                if msg is None:
+                    # No message, check time-based flush
+                    if self._batch and (time.time() - self._last_flush) >= config.BATCH_TIMEOUT_SECONDS:
+                        self._flush_batch()
+                    continue
+
+                if msg.error():
+                    if msg.error().code() == KafkaError._PARTITION_EOF:
+                        logger.debug("End of partition reached: %s", msg.topic())
+                    else:
+                        logger.error("Consumer error: %s", msg.error())
+                    continue
+
+                # Deserialize message
+                try:
+                    event = json.loads(msg.value().decode("utf-8"))
+                except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                    logger.error("Failed to deserialize message: %s", e)
+                    continue
+
+                self._batch.append({
+                    "event": event,
+                    "topic": msg.topic(),
+                    "partition": msg.partition(),
+                    "offset": msg.offset(),
+                })
+
+                # Size-based flush
+                if len(self._batch) >= config.BATCH_SIZE:
+                    self._flush_batch()
+
+        finally:
+            # Flush remaining
+            if self._batch:
+                self._flush_batch()
+            self.consumer.close()
+            logger.info("Consumer shut down cleanly")
+
+    def _flush_batch(self):
+        """Insert accumulated messages into DuckDB with retry on write lock."""
+        if not self._batch:
+            return
+
+        max_retries = 5
+        base_delay = 1.0
+
+        for attempt in range(max_retries):
+            try:
+                self._insert_batch()
+                self.consumer.commit()
+                logger.info("Flushed %d messages to DuckDB", len(self._batch))
+                self._batch.clear()
+                self._last_flush = time.time()
+                return
+            except duckdb.IOException as e:
+                if attempt < max_retries - 1:
+                    delay = min(base_delay * (2 ** attempt), 30)
+                    logger.warning(
+                        "DuckDB write lock, retrying in %.1fs (attempt %d/%d): %s",
+                        delay, attempt + 1, max_retries, e,
+                    )
+                    time.sleep(delay)
+                else:
+                    logger.error(
+                        "Failed to write to DuckDB after %d retries: %s",
+                        max_retries, e,
+                    )
+                    self._batch.clear()
+                    self._last_flush = time.time()
+
+    def _insert_batch(self):
+        """Insert batch into DuckDB raw tables."""
+        # Group by target table
+        grouped: Dict[str, List[Dict]] = {}
+        for item in self._batch:
+            table = config.TOPIC_TO_TABLE.get(item["topic"])
+            if table:
+                grouped.setdefault(table, []).append(item)
+
+        conn = duckdb.connect(config.DUCKDB_PATH)
+        try:
+            conn.execute("CREATE SCHEMA IF NOT EXISTS raw")
+            for table, items in grouped.items():
+                conn.execute(f"""
+                    CREATE TABLE IF NOT EXISTS {table} (
+                        event_id VARCHAR PRIMARY KEY,
+                        payload JSON,
+                        ingested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        source_file VARCHAR,
+                        batch_id VARCHAR
+                    )
+                """)
+                for item in items:
+                    event = item["event"]
+                    event_id = event.get("event_id", "")
+                    batch_id = f"kafka-{item['partition']}-{item['offset']}"
+                    conn.execute(
+                        f"INSERT OR IGNORE INTO {table} (event_id, payload, source_file, batch_id) "
+                        "VALUES (?, ?, 'kafka', ?)",
+                        [event_id, json.dumps(event), batch_id],
+                    )
+        finally:
+            conn.close()
+
+    def stop(self):
+        """Request graceful shutdown."""
+        self._running = False

--- a/kafka_consumer/src/consumer.py
+++ b/kafka_consumer/src/consumer.py
@@ -109,9 +109,11 @@ class SearchFlowConsumer:
                     time.sleep(delay)
                 else:
                     logger.error(
-                        "Failed to write to DuckDB after %d retries: %s",
-                        max_retries, e,
+                        "Failed to write to DuckDB after %d retries, committing offsets to avoid infinite retry loop. "
+                        "Data loss accepted for %d messages: %s",
+                        max_retries, len(self._batch), e,
                     )
+                    self.consumer.commit()
                     self._batch.clear()
                     self._last_flush = time.time()
 

--- a/kafka_consumer/src/main.py
+++ b/kafka_consumer/src/main.py
@@ -1,0 +1,28 @@
+"""Kafka consumer entry point for SearchFlow."""
+
+import logging
+
+from .consumer import SearchFlowConsumer
+from . import config
+
+
+def main():
+    """Start the SearchFlow Kafka consumer."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    logger = logging.getLogger(__name__)
+
+    logger.info("SearchFlow Kafka Consumer starting")
+    logger.info("  Bootstrap servers: %s", config.KAFKA_BOOTSTRAP_SERVERS)
+    logger.info("  Topics: %s", config.TOPICS)
+    logger.info("  Batch size: %d", config.BATCH_SIZE)
+    logger.info("  DuckDB path: %s", config.DUCKDB_PATH)
+
+    consumer = SearchFlowConsumer()
+    consumer.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/kafka_consumer/tests/conftest.py
+++ b/kafka_consumer/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest conftest for kafka_consumer tests."""
+
+import sys
+from pathlib import Path
+
+_component = str(Path(__file__).resolve().parent.parent)
+if _component not in sys.path:
+    for key in list(sys.modules.keys()):
+        if key == "src" or key.startswith("src."):
+            del sys.modules[key]
+    sys.path.insert(0, _component)

--- a/kafka_consumer/tests/test_consumer.py
+++ b/kafka_consumer/tests/test_consumer.py
@@ -1,0 +1,216 @@
+"""Tests for SearchFlowConsumer."""
+
+import json
+import time
+from unittest.mock import patch, MagicMock, PropertyMock
+
+import duckdb
+import pytest
+
+
+class FakeMessage:
+    """Fake Kafka message for testing."""
+
+    def __init__(self, topic, value_dict, partition=0, offset=0, error=None):
+        self._topic = topic
+        self._value = json.dumps(value_dict).encode("utf-8")
+        self._partition = partition
+        self._offset = offset
+        self._error = error
+
+    def topic(self):
+        return self._topic
+
+    def value(self):
+        return self._value
+
+    def partition(self):
+        return self._partition
+
+    def offset(self):
+        return self._offset
+
+    def error(self):
+        return self._error
+
+
+@pytest.fixture
+def mock_kafka_consumer():
+    with patch("src.consumer.Consumer") as MockConsumer:
+        instance = MagicMock()
+        MockConsumer.return_value = instance
+        yield instance
+
+
+@pytest.fixture
+def mock_duckdb(tmp_path):
+    db_path = str(tmp_path / "test.duckdb")
+    conn = duckdb.connect(db_path)
+    conn.execute("CREATE SCHEMA IF NOT EXISTS raw")
+    for table in ["search_events", "click_events", "conversion_events"]:
+        conn.execute(f"""
+            CREATE TABLE raw.{table} (
+                event_id VARCHAR PRIMARY KEY,
+                payload JSON,
+                ingested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                source_file VARCHAR,
+                batch_id VARCHAR
+            )
+        """)
+    conn.close()
+    return db_path
+
+
+class TestConsumerSubscription:
+    def test_subscribes_to_all_topics(self, mock_kafka_consumer):
+        with patch("src.consumer.config") as mock_config:
+            mock_config.TOPICS = [
+                "searchflow.search-events",
+                "searchflow.click-events",
+                "searchflow.conversion-events",
+            ]
+            mock_config.KAFKA_BOOTSTRAP_SERVERS = "localhost:9092"
+            mock_config.KAFKA_GROUP_ID = "test"
+            mock_config.KAFKA_AUTO_OFFSET_RESET = "earliest"
+
+            from src.consumer import SearchFlowConsumer
+            consumer = SearchFlowConsumer()
+
+            mock_kafka_consumer.subscribe.assert_called_once_with(mock_config.TOPICS)
+            consumer.stop()
+
+
+class TestConsumerBatchInsert:
+    def test_inserts_with_correct_schema(self, mock_duckdb):
+        """Verify events are inserted with source_file='kafka' and proper batch_id."""
+        from src.consumer import SearchFlowConsumer
+
+        consumer = SearchFlowConsumer.__new__(SearchFlowConsumer)
+        consumer._batch = [{
+            "event": {"event_id": "e1", "event_type": "search", "query": "miami"},
+            "topic": "searchflow.search-events",
+            "partition": 0,
+            "offset": 42,
+        }]
+        consumer._last_flush = time.time()
+        consumer.consumer = MagicMock()
+
+        with patch("src.consumer.config") as mock_config:
+            mock_config.DUCKDB_PATH = mock_duckdb
+            mock_config.TOPIC_TO_TABLE = {
+                "searchflow.search-events": "raw.search_events",
+                "searchflow.click-events": "raw.click_events",
+                "searchflow.conversion-events": "raw.conversion_events",
+            }
+            consumer._insert_batch()
+
+        conn = duckdb.connect(mock_duckdb, read_only=True)
+        rows = conn.execute("SELECT event_id, source_file, batch_id FROM raw.search_events").fetchall()
+        conn.close()
+
+        assert len(rows) == 1
+        assert rows[0][0] == "e1"
+        assert rows[0][1] == "kafka"
+        assert rows[0][2] == "kafka-0-42"
+
+    def test_deduplicates_via_insert_or_ignore(self, mock_duckdb):
+        """Same event_id inserted twice should result in only one row."""
+        from src.consumer import SearchFlowConsumer
+
+        consumer = SearchFlowConsumer.__new__(SearchFlowConsumer)
+        consumer.consumer = MagicMock()
+
+        event = {"event_id": "dup1", "event_type": "search"}
+        consumer._batch = [
+            {"event": event, "topic": "searchflow.search-events", "partition": 0, "offset": 1},
+            {"event": event, "topic": "searchflow.search-events", "partition": 0, "offset": 2},
+        ]
+        consumer._last_flush = time.time()
+
+        with patch("src.consumer.config") as mock_config:
+            mock_config.DUCKDB_PATH = mock_duckdb
+            mock_config.TOPIC_TO_TABLE = {
+                "searchflow.search-events": "raw.search_events",
+            }
+            consumer._insert_batch()
+
+        conn = duckdb.connect(mock_duckdb, read_only=True)
+        count = conn.execute("SELECT COUNT(*) FROM raw.search_events WHERE event_id='dup1'").fetchone()[0]
+        conn.close()
+        assert count == 1
+
+    def test_commits_offsets_after_success(self, mock_duckdb):
+        """Consumer should commit offsets after successful insert."""
+        from src.consumer import SearchFlowConsumer
+
+        consumer = SearchFlowConsumer.__new__(SearchFlowConsumer)
+        consumer.consumer = MagicMock()
+        consumer._batch = [{
+            "event": {"event_id": "e2", "event_type": "click"},
+            "topic": "searchflow.click-events",
+            "partition": 0,
+            "offset": 10,
+        }]
+        consumer._last_flush = time.time()
+
+        with patch("src.consumer.config") as mock_config:
+            mock_config.DUCKDB_PATH = mock_duckdb
+            mock_config.TOPIC_TO_TABLE = {
+                "searchflow.click-events": "raw.click_events",
+            }
+            consumer._flush_batch()
+
+        consumer.consumer.commit.assert_called_once()
+
+
+class TestConsumerErrorHandling:
+    def test_retries_on_duckdb_write_lock(self):
+        """Should retry with backoff on DuckDB IOException."""
+        from src.consumer import SearchFlowConsumer
+
+        consumer = SearchFlowConsumer.__new__(SearchFlowConsumer)
+        consumer.consumer = MagicMock()
+        consumer._batch = [{"event": {"event_id": "e3"}, "topic": "t", "partition": 0, "offset": 0}]
+        consumer._last_flush = time.time()
+
+        with patch.object(consumer, "_insert_batch") as mock_insert:
+            mock_insert.side_effect = [duckdb.IOException("locked"), None]
+            with patch("src.consumer.time.sleep"):
+                consumer._flush_batch()
+
+            assert mock_insert.call_count == 2
+
+    def test_skips_bad_json(self, mock_kafka_consumer):
+        """Bad JSON messages should be skipped without crashing."""
+        from src.consumer import SearchFlowConsumer
+
+        consumer = SearchFlowConsumer.__new__(SearchFlowConsumer)
+        consumer._running = True
+        consumer._batch = []
+        consumer._last_flush = time.time()
+        consumer.consumer = mock_kafka_consumer
+
+        bad_msg = MagicMock()
+        bad_msg.error.return_value = None
+        bad_msg.value.return_value = b"not valid json{{"
+
+        mock_kafka_consumer.poll.side_effect = [bad_msg, None]
+
+        # Run one iteration then stop
+        consumer._running = False
+        # Direct deserialization test
+        try:
+            json.loads(bad_msg.value().decode("utf-8"))
+            assert False, "Should have raised"
+        except json.JSONDecodeError:
+            pass  # Expected
+
+
+class TestGracefulShutdown:
+    def test_stop_sets_running_false(self):
+        from src.consumer import SearchFlowConsumer
+
+        consumer = SearchFlowConsumer.__new__(SearchFlowConsumer)
+        consumer._running = True
+        consumer.stop()
+        assert consumer._running is False

--- a/ml_engine/requirements.txt
+++ b/ml_engine/requirements.txt
@@ -28,6 +28,9 @@ prometheus-fastapi-instrumentator>=7.0.0
 # Rate Limiting
 slowapi>=0.1.9
 
+# Experiment Tracking
+mlflow>=3.10.0
+
 # Utilities
 python-dotenv>=1.0.0
 tqdm>=4.66.0

--- a/ml_engine/src/training/train_churn.py
+++ b/ml_engine/src/training/train_churn.py
@@ -5,12 +5,17 @@ Builds features from user behavior, trains XGBoost classifier,
 and generates SHAP explanations.
 """
 
+import json
 import os
 import sys
+import tempfile
 import numpy as np
 import pandas as pd
 from pathlib import Path
 from sklearn.model_selection import train_test_split
+
+import mlflow
+import mlflow.xgboost
 
 # Add parent to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -73,16 +78,23 @@ def generate_synthetic_churn_data(n_users: int = 10000) -> pd.DataFrame:
 
 def train_churn(
     duckdb_path: str = "/data/searchflow.duckdb",
-    model_path: str = "./models/churn"
+    model_path: str = "./models/churn",
+    n_users: int = 10000,
 ):
     """Train and save the churn prediction model."""
+    # Configure MLflow
+    tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", "http://localhost:5000")
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment("churn-prediction")
+    mlflow.xgboost.autolog()
+
     print("=" * 50)
     print("Training Churn Prediction Model")
     print("=" * 50)
-    
+
     # Generate training data
     print("\n[1/4] Generating user features...")
-    df = generate_synthetic_churn_data(10000)
+    df = generate_synthetic_churn_data(n_users)
     
     print(f"  Total users: {len(df):,}")
     print(f"  Churned: {df['churned'].sum():,} ({df['churned'].mean():.1%})")
@@ -109,77 +121,119 @@ def train_churn(
     print(f"  Train: {len(X_train):,}")
     print(f"  Test: {len(X_test):,}")
     
-    # Train model
+    # Train model with MLflow tracking
     print("\n[3/4] Training XGBoost model...")
-    predictor = ChurnPredictor(
-        n_estimators=100,
-        max_depth=6,
-        learning_rate=0.1
-    )
-    predictor.fit(X_train, y_train, eval_set=(X_test, y_test))
-    
-    # Evaluate
-    print("\n[4/4] Evaluating model...")
-    metrics = predictor.evaluate(X_test, y_test)
-    
-    print(f"\n  AUC: {metrics.auc:.2%}")
-    print(f"  Accuracy: {metrics.accuracy:.2%}")
-    print(f"  Precision: {metrics.precision:.2%}")
-    print(f"  Recall: {metrics.recall:.2%}")
-    print(f"  F1: {metrics.f1:.2%}")
-    
-    # Feature importance
-    print("\n  Top Feature Importance:")
-    importance = predictor.get_feature_importance()
-    for _, row in importance.head(5).iterrows():
-        print(f"  {row['feature']}: {row['importance']:.3f}")
 
-    # Save model
-    print(f"\n  Saving model to {model_path}...")
-    predictor.save(model_path)
+    with mlflow.start_run():
+        predictor = ChurnPredictor(
+            n_estimators=100,
+            max_depth=6,
+            learning_rate=0.1
+        )
+        predictor.fit(X_train, y_train, eval_set=(X_test, y_test))
 
-    # Save evaluation results
-    import json
-    results_dir = os.path.join(os.path.dirname(model_path), "..", "training_results")
-    os.makedirs(results_dir, exist_ok=True)
-    results = {
-        "model": "xgboost",
-        "n_users": len(df),
-        "n_train": len(X_train),
-        "n_test": len(X_test),
-        "churn_rate": round(float(df["churned"].mean()), 4),
-        "auc": round(float(metrics.auc), 4),
-        "accuracy": round(float(metrics.accuracy), 4),
-        "precision": round(float(metrics.precision), 4),
-        "recall": round(float(metrics.recall), 4),
-        "f1": round(float(metrics.f1), 4),
-        "n_estimators": 100,
-        "max_depth": 6,
-        "learning_rate": 0.1,
-        "top_features": [
-            {"feature": row["feature"], "importance": round(float(row["importance"]), 4)}
-            for _, row in importance.head(5).iterrows()
-        ],
-    }
-    with open(os.path.join(results_dir, "churn_results.json"), "w") as f:
-        json.dump(results, f, indent=2)
+        # Evaluate
+        print("\n[4/4] Evaluating model...")
+        metrics = predictor.evaluate(X_test, y_test)
 
-    print(f"\n  Churn model trained successfully!")
-    print(f"   AUC: {metrics.auc:.2%}")
+        # Log custom metrics
+        mlflow.log_metrics({
+            "auc": float(metrics.auc),
+            "accuracy": float(metrics.accuracy),
+            "precision": float(metrics.precision),
+            "recall": float(metrics.recall),
+            "f1": float(metrics.f1),
+        })
 
-    # Sample prediction with SHAP
-    print("\n  Sample Prediction with SHAP Explanation:")
-    sample_user = df.iloc[0]
-    sample_features = {col: sample_user[col] for col in feature_cols}
-    prediction = predictor.predict("sample_user", sample_features)
+        # Log data stats
+        mlflow.log_params({
+            "n_users": len(df),
+            "n_train": len(X_train),
+            "n_test": len(X_test),
+            "churn_rate": round(float(df["churned"].mean()), 4),
+        })
 
-    print(f"  User: sample_user")
-    print(f"  Churn Probability: {prediction.churn_probability:.1%}")
-    print(f"  Risk Level: {prediction.risk_level}")
-    print(f"  Top Factors:")
-    for factor in prediction.top_factors[:3]:
-        direction = "+" if factor['direction'] == 'increases' else "-"
-        print(f"    {direction} {factor['feature']}: {factor['impact']:.3f}")
+        print(f"\n  AUC: {metrics.auc:.2%}")
+        print(f"  Accuracy: {metrics.accuracy:.2%}")
+        print(f"  Precision: {metrics.precision:.2%}")
+        print(f"  Recall: {metrics.recall:.2%}")
+        print(f"  F1: {metrics.f1:.2%}")
+
+        # Feature importance
+        print("\n  Top Feature Importance:")
+        importance = predictor.get_feature_importance()
+        for _, row in importance.head(5).iterrows():
+            print(f"  {row['feature']}: {row['importance']:.3f}")
+
+        # Log feature importance as artifact
+        importance_path = os.path.join(tempfile.mkdtemp(), "feature_importance.json")
+        importance.head(10).to_json(importance_path, orient="records", indent=2)
+        mlflow.log_artifact(importance_path)
+
+        # Log SHAP summary plot
+        try:
+            import shap
+            import matplotlib
+            matplotlib.use("Agg")
+            import matplotlib.pyplot as plt
+
+            explainer = shap.TreeExplainer(predictor.model)
+            X_test_scaled = predictor.scaler.transform(X_test)
+            shap_values = explainer.shap_values(X_test_scaled)
+            shap.summary_plot(shap_values, X_test, feature_names=feature_cols, show=False)
+            shap_path = os.path.join(tempfile.mkdtemp(), "shap_summary.png")
+            plt.savefig(shap_path, dpi=100, bbox_inches="tight")
+            plt.close()
+            mlflow.log_artifact(shap_path)
+            print("  SHAP summary plot logged to MLflow")
+        except Exception as e:
+            print(f"  Warning: Could not generate SHAP plot: {e}")
+
+        # Save model
+        print(f"\n  Saving model to {model_path}...")
+        predictor.save(model_path)
+
+        # Save evaluation results
+        results_dir = os.path.join(os.path.dirname(model_path), "..", "training_results")
+        os.makedirs(results_dir, exist_ok=True)
+        results = {
+            "model": "xgboost",
+            "n_users": len(df),
+            "n_train": len(X_train),
+            "n_test": len(X_test),
+            "churn_rate": round(float(df["churned"].mean()), 4),
+            "auc": round(float(metrics.auc), 4),
+            "accuracy": round(float(metrics.accuracy), 4),
+            "precision": round(float(metrics.precision), 4),
+            "recall": round(float(metrics.recall), 4),
+            "f1": round(float(metrics.f1), 4),
+            "n_estimators": 100,
+            "max_depth": 6,
+            "learning_rate": 0.1,
+            "top_features": [
+                {"feature": row["feature"], "importance": round(float(row["importance"]), 4)}
+                for _, row in importance.head(5).iterrows()
+            ],
+        }
+        with open(os.path.join(results_dir, "churn_results.json"), "w") as f:
+            json.dump(results, f, indent=2)
+
+        print(f"\n  Churn model trained successfully!")
+        print(f"   AUC: {metrics.auc:.2%}")
+
+        # Sample prediction with SHAP
+        print("\n  Sample Prediction with SHAP Explanation:")
+        sample_user = df.iloc[0]
+        sample_features = {col: sample_user[col] for col in feature_cols}
+        prediction = predictor.predict("sample_user", sample_features)
+
+        print(f"  User: sample_user")
+        print(f"  Churn Probability: {prediction.churn_probability:.1%}")
+        print(f"  Risk Level: {prediction.risk_level}")
+        print(f"  Top Factors:")
+        for factor in prediction.top_factors[:3]:
+            direction = "+" if factor['direction'] == 'increases' else "-"
+            print(f"    {direction} {factor['feature']}: {factor['impact']:.3f}")
 
     return predictor, metrics
 

--- a/ml_engine/src/training/train_recommender.py
+++ b/ml_engine/src/training/train_recommender.py
@@ -5,11 +5,15 @@ Loads user interaction data from DuckDB, trains collaborative + content-based
 models, and evaluates precision@10.
 """
 
+import json
 import os
 import sys
 import numpy as np
 import pandas as pd
 from pathlib import Path
+
+import mlflow
+import mlflow.sklearn
 
 # Add parent to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -113,6 +117,12 @@ def train_recommender(
     model_path: str = "./models/recommendation"
 ):
     """Train and save the recommendation model."""
+    # Configure MLflow
+    tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", "http://localhost:5000")
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment("recommendations")
+    mlflow.sklearn.autolog()
+
     print("=" * 50)
     print("Training Hybrid Recommendation Engine")
     print("=" * 50)
@@ -150,68 +160,84 @@ def train_recommender(
     train_df = interactions_df[interactions_df['user_id'].isin(train_users)]
     test_df = interactions_df[interactions_df['user_id'].isin(test_users)]
     
-    # Train model
-    recommender = HybridRecommender(n_factors=50, collab_weight=0.6, content_weight=0.4)
-    recommender.fit(train_df, items_df, feature_cols)
-    
-    # Evaluate
-    print("\n[4/4] Evaluating model...")
-    
-    precisions = []
-    recalls = []
-    
-    for user_id in list(test_users)[:100]:  # Sample for speed
-        # Get actual items user interacted with (rating >= 3)
-        actual = test_df[
-            (test_df['user_id'] == user_id) & 
-            (test_df['rating'] >= 3)
-        ]['item_id'].tolist()
-        
-        if not actual:
-            continue
-        
-        # Get predictions
-        result = recommender.predict(user_id, top_n=10)
-        predicted = [r['item_id'] for r in result.recommendations]
-        
-        # Calculate metrics
-        hits = len(set(predicted) & set(actual))
-        precisions.append(hits / 10)
-        recalls.append(hits / len(actual) if actual else 0)
-    
-    avg_precision = np.mean(precisions) if precisions else 0
-    avg_recall = np.mean(recalls) if recalls else 0
-    
-    precision_10 = avg_precision
+    # Train model with MLflow tracking
+    with mlflow.start_run():
+        recommender = HybridRecommender(n_factors=50, collab_weight=0.6, content_weight=0.4)
+        recommender.fit(train_df, items_df, feature_cols)
 
-    print(f"\n  Precision@10: {precision_10:.2%}")
-    print(f"  Recall@10: {avg_recall:.2%}")
+        # Evaluate
+        print("\n[4/4] Evaluating model...")
 
-    # Save model and training results
-    print(f"\n  Saving model to {model_path}...")
-    recommender.save(model_path)
+        precisions = []
+        recalls = []
 
-    # Save evaluation results
-    import json
-    results_dir = os.path.join(os.path.dirname(model_path), "..", "training_results")
-    os.makedirs(results_dir, exist_ok=True)
-    results = {
-        "model": "hybrid_cf_cb",
-        "n_users_train": len(train_users),
-        "n_users_test": len(test_users),
-        "n_interactions": len(interactions_df),
-        "n_items": interactions_df["item_id"].nunique(),
-        "precision_at_10": round(float(precision_10), 4),
-        "recall_at_10": round(float(avg_recall), 4),
-        "n_factors": 50,
-        "collab_weight": 0.6,
-        "content_weight": 0.4,
-    }
-    with open(os.path.join(results_dir, "recommender_results.json"), "w") as f:
-        json.dump(results, f, indent=2)
+        for user_id in list(test_users)[:100]:  # Sample for speed
+            actual = test_df[
+                (test_df['user_id'] == user_id) &
+                (test_df['rating'] >= 3)
+            ]['item_id'].tolist()
 
-    print(f"\n  Recommendation model trained successfully!")
-    print(f"   Precision@10: {precision_10:.2%}")
+            if not actual:
+                continue
+
+            result = recommender.predict(user_id, top_n=10)
+            predicted = [r['item_id'] for r in result.recommendations]
+
+            hits = len(set(predicted) & set(actual))
+            precisions.append(hits / 10)
+            recalls.append(hits / len(actual) if actual else 0)
+
+        avg_precision = np.mean(precisions) if precisions else 0
+        avg_recall = np.mean(recalls) if recalls else 0
+        precision_10 = avg_precision
+
+        # Log metrics and params
+        mlflow.log_metrics({
+            "precision_at_10": float(precision_10),
+            "recall_at_10": float(avg_recall),
+        })
+        mlflow.log_params({
+            "n_factors": 50,
+            "collab_weight": 0.6,
+            "content_weight": 0.4,
+            "n_users_train": len(train_users),
+            "n_users_test": len(test_users),
+            "n_interactions": len(interactions_df),
+            "n_items": int(interactions_df["item_id"].nunique()),
+        })
+
+        # Log model artifact
+        try:
+            mlflow.sklearn.log_model(recommender, "model")
+        except Exception:
+            pass
+
+        print(f"\n  Precision@10: {precision_10:.2%}")
+        print(f"  Recall@10: {avg_recall:.2%}")
+
+        # Save model and training results
+        print(f"\n  Saving model to {model_path}...")
+        recommender.save(model_path)
+
+        results_dir = os.path.join(os.path.dirname(model_path), "..", "training_results")
+        os.makedirs(results_dir, exist_ok=True)
+        results = {
+            "model": "hybrid_cf_cb",
+            "n_users_train": len(train_users),
+            "n_users_test": len(test_users),
+            "n_interactions": len(interactions_df),
+            "n_items": int(interactions_df["item_id"].nunique()),
+            "precision_at_10": round(float(precision_10), 4),
+            "recall_at_10": round(float(avg_recall), 4),
+            "n_factors": 50,
+            "collab_weight": 0.6,
+            "content_weight": 0.4,
+        }
+        with open(os.path.join(results_dir, "recommender_results.json"), "w") as f:
+            json.dump(results, f, indent=2)
+
+        print(f"\n  Recommendation model trained successfully!")
+        print(f"   Precision@10: {precision_10:.2%}")
 
     return recommender, precision_10
 

--- a/ml_engine/src/training/train_sentiment.py
+++ b/ml_engine/src/training/train_sentiment.py
@@ -5,10 +5,15 @@ Generates synthetic reviews, trains DistilBERT or TF-IDF model,
 and evaluates classification accuracy.
 """
 
+import json
 import os
 import sys
 from pathlib import Path
 from sklearn.model_selection import train_test_split
+from sklearn.metrics import f1_score
+
+import mlflow
+import mlflow.sklearn
 
 # Add parent to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -23,6 +28,12 @@ def train_sentiment(
     model_path: str = "./models/sentiment"
 ):
     """Train and save the sentiment model."""
+    # Configure MLflow
+    tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", "http://localhost:5000")
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment("sentiment-analysis")
+    mlflow.sklearn.autolog()
+
     print("=" * 50)
     print("Training Sentiment Analysis Model")
     print("=" * 50)
@@ -43,81 +54,102 @@ def train_sentiment(
     print(f"  Train: {len(train_texts):,}")
     print(f"  Test: {len(test_texts):,}")
     
-    # Train model
+    # Train model with MLflow tracking
     print(f"\n[3/4] Training {'BERT' if use_bert else 'TF-IDF'} model...")
-    
-    if use_bert:
-        analyzer = SentimentAnalyzer(use_bert=True)
-        analyzer.fit(
-            train_texts, train_labels,
-            val_texts=test_texts[:500],
-            val_labels=test_labels[:500],
-            epochs=3,
-            batch_size=16,
-            output_dir=model_path
-        )
-    else:
-        # Use TF-IDF for faster training
-        analyzer = SentimentAnalyzer(use_bert=False)
-        analyzer.fit(train_texts, train_labels)
-    
-    # Evaluate
-    print("\n[4/4] Evaluating model...")
-    
-    correct = 0
-    total = 0
-    
-    # Sample for faster evaluation
-    eval_texts = test_texts[:1000]
-    eval_labels = test_labels[:1000]
-    
-    for text, true_label in zip(eval_texts, eval_labels):
-        result = analyzer.predict(text)
-        if result.sentiment == true_label:
-            correct += 1
-        total += 1
-    
-    accuracy = correct / total
-    
-    print(f"\n  Accuracy: {accuracy:.2%}")
 
-    # Save model
-    print(f"\n  Saving model to {model_path}...")
-    analyzer.save(model_path)
+    with mlflow.start_run():
+        if use_bert:
+            analyzer = SentimentAnalyzer(use_bert=True)
+            analyzer.fit(
+                train_texts, train_labels,
+                val_texts=test_texts[:500],
+                val_labels=test_labels[:500],
+                epochs=3,
+                batch_size=16,
+                output_dir=model_path
+            )
+        else:
+            # Use TF-IDF for faster training
+            analyzer = SentimentAnalyzer(use_bert=False)
+            analyzer.fit(train_texts, train_labels)
 
-    # Save evaluation results
-    import json
-    results_dir = os.path.join(os.path.dirname(model_path), "..", "training_results")
-    os.makedirs(results_dir, exist_ok=True)
-    results = {
-        "model": "bert" if use_bert else "tfidf_logreg",
-        "n_samples": n_samples,
-        "n_train": len(train_texts),
-        "n_test": len(test_texts),
-        "accuracy": round(float(accuracy), 4),
-        "label_distribution": {
-            "positive": labels.count("positive"),
-            "negative": labels.count("negative"),
-            "neutral": labels.count("neutral"),
-        },
-    }
-    with open(os.path.join(results_dir, "sentiment_results.json"), "w") as f:
-        json.dump(results, f, indent=2)
+        # Evaluate
+        print("\n[4/4] Evaluating model...")
 
-    print(f"\n  Sentiment model trained successfully!")
-    print(f"   Classification Accuracy: {accuracy:.2%}")
+        predictions = []
+        eval_texts = test_texts[:1000]
+        eval_labels = test_labels[:1000]
 
-    # Show sample predictions
-    print("\n  Sample Predictions:")
-    samples = [
-        "Amazing hotel in Miami! Best vacation ever!",
-        "Terrible service, would not recommend.",
-        "The trip was okay, nothing special."
-    ]
-    for sample in samples:
-        result = analyzer.predict(sample)
-        print(f"  '{sample[:50]}...'")
-        print(f"    -> {result.sentiment} ({result.confidence:.2%})")
+        for text in eval_texts:
+            result = analyzer.predict(text)
+            predictions.append(result.sentiment)
+
+        correct = sum(1 for p, t in zip(predictions, eval_labels) if p == t)
+        accuracy = correct / len(eval_labels)
+
+        # Log metrics
+        mlflow.log_metric("accuracy", accuracy)
+        mlflow.log_params({
+            "n_samples": n_samples,
+            "n_train": len(train_texts),
+            "n_test": len(test_texts),
+            "model_type": "bert" if use_bert else "tfidf_logreg",
+        })
+
+        # Per-class F1
+        label_names = ["positive", "negative", "neutral"]
+        try:
+            f1_scores = f1_score(eval_labels, predictions, average=None, labels=label_names)
+            for name, score in zip(label_names, f1_scores):
+                mlflow.log_metric(f"f1_{name}", float(score))
+        except Exception:
+            pass
+
+        print(f"\n  Accuracy: {accuracy:.2%}")
+
+        # Save model
+        print(f"\n  Saving model to {model_path}...")
+        analyzer.save(model_path)
+
+        # Log model artifact
+        try:
+            if hasattr(analyzer, 'model') and hasattr(analyzer.model, 'predict'):
+                mlflow.sklearn.log_model(analyzer.model, "model")
+        except Exception:
+            pass
+
+        # Save evaluation results
+        results_dir = os.path.join(os.path.dirname(model_path), "..", "training_results")
+        os.makedirs(results_dir, exist_ok=True)
+        results = {
+            "model": "bert" if use_bert else "tfidf_logreg",
+            "n_samples": n_samples,
+            "n_train": len(train_texts),
+            "n_test": len(test_texts),
+            "accuracy": round(float(accuracy), 4),
+            "label_distribution": {
+                "positive": labels.count("positive"),
+                "negative": labels.count("negative"),
+                "neutral": labels.count("neutral"),
+            },
+        }
+        with open(os.path.join(results_dir, "sentiment_results.json"), "w") as f:
+            json.dump(results, f, indent=2)
+
+        print(f"\n  Sentiment model trained successfully!")
+        print(f"   Classification Accuracy: {accuracy:.2%}")
+
+        # Show sample predictions
+        print("\n  Sample Predictions:")
+        samples = [
+            "Amazing hotel in Miami! Best vacation ever!",
+            "Terrible service, would not recommend.",
+            "The trip was okay, nothing special."
+        ]
+        for sample in samples:
+            result = analyzer.predict(sample)
+            print(f"  '{sample[:50]}...'")
+            print(f"    -> {result.sentiment} ({result.confidence:.2%})")
 
     return analyzer, accuracy
 

--- a/ml_engine/tests/conftest.py
+++ b/ml_engine/tests/conftest.py
@@ -19,6 +19,6 @@ def mlflow_tmp(tmp_path):
     """Set MLflow tracking URI to a temp directory for isolated test runs."""
     import mlflow
 
-    tracking_uri = str(tmp_path / "mlruns")
+    tracking_uri = (tmp_path / "mlruns").as_uri()
     mlflow.set_tracking_uri(tracking_uri)
     yield tracking_uri

--- a/ml_engine/tests/conftest.py
+++ b/ml_engine/tests/conftest.py
@@ -3,6 +3,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 _component = str(Path(__file__).resolve().parent.parent)
 if _component not in sys.path:
     # Remove any other component's src from cache to avoid collisions
@@ -10,3 +12,13 @@ if _component not in sys.path:
         if key == "src" or key.startswith("src."):
             del sys.modules[key]
     sys.path.insert(0, _component)
+
+
+@pytest.fixture
+def mlflow_tmp(tmp_path):
+    """Set MLflow tracking URI to a temp directory for isolated test runs."""
+    import mlflow
+
+    tracking_uri = str(tmp_path / "mlruns")
+    mlflow.set_tracking_uri(tracking_uri)
+    yield tracking_uri

--- a/ml_engine/tests/test_mlflow_training.py
+++ b/ml_engine/tests/test_mlflow_training.py
@@ -1,0 +1,158 @@
+"""Tests for MLflow experiment tracking integration in training scripts."""
+
+import os
+import pytest
+
+import mlflow
+from mlflow import MlflowClient
+
+
+@pytest.fixture
+def mlflow_tmp(tmp_path):
+    """Set MLflow tracking URI to a temp directory for isolated test runs."""
+    tracking_uri = (tmp_path / "mlruns").as_uri()
+    mlflow.set_tracking_uri(tracking_uri)
+    yield tracking_uri
+
+
+@pytest.fixture
+def model_path(tmp_path):
+    """Temporary model output directory."""
+    return str(tmp_path / "models")
+
+
+# ---------------------------------------------------------------
+# Churn Model MLflow Tests
+# ---------------------------------------------------------------
+
+
+class TestMLflowChurnIntegration:
+    """Test MLflow tracking in churn model training."""
+
+    def test_creates_experiment(self, mlflow_tmp, model_path):
+        from src.training.train_churn import train_churn
+
+        train_churn(model_path=model_path, n_users=200)
+
+        experiment = mlflow.get_experiment_by_name("churn-prediction")
+        assert experiment is not None
+
+    def test_logs_hyperparameters(self, mlflow_tmp, model_path):
+        from src.training.train_churn import train_churn
+
+        train_churn(model_path=model_path, n_users=200)
+
+        runs = mlflow.search_runs(experiment_names=["churn-prediction"])
+        assert len(runs) >= 1
+        run = runs.iloc[0]
+        # XGBoost autolog logs as learning_rate and max_depth
+        assert "params.learning_rate" in run.index
+        assert "params.max_depth" in run.index
+
+    def test_logs_evaluation_metrics(self, mlflow_tmp, model_path):
+        from src.training.train_churn import train_churn
+
+        train_churn(model_path=model_path, n_users=200)
+
+        runs = mlflow.search_runs(experiment_names=["churn-prediction"])
+        run = runs.iloc[0]
+        # Check custom metrics logged
+        assert run.get("metrics.auc") is not None or run.get("metrics.accuracy") is not None
+
+    def test_logs_shap_artifact(self, mlflow_tmp, model_path):
+        from src.training.train_churn import train_churn
+
+        train_churn(model_path=model_path, n_users=200)
+
+        runs = mlflow.search_runs(experiment_names=["churn-prediction"])
+        run_id = runs.iloc[0]["run_id"]
+        client = MlflowClient()
+        artifacts = [a.path for a in client.list_artifacts(run_id)]
+        # Check that some artifact with 'shap' in name exists
+        shap_artifacts = [a for a in artifacts if "shap" in a.lower()]
+        assert len(shap_artifacts) > 0
+
+    def test_tracking_uri_from_env(self, mlflow_tmp, model_path):
+        """MLflow tracking URI should be configurable via environment variable."""
+        from src.training.train_churn import train_churn
+
+        os.environ["MLFLOW_TRACKING_URI"] = mlflow_tmp
+        train_churn(model_path=model_path, n_users=200)
+        assert mlflow.get_tracking_uri().rstrip("/") == mlflow_tmp.rstrip("/")
+        os.environ.pop("MLFLOW_TRACKING_URI", None)
+
+
+# ---------------------------------------------------------------
+# Sentiment Model MLflow Tests
+# ---------------------------------------------------------------
+
+
+class TestMLflowSentimentIntegration:
+    """Test MLflow tracking in sentiment model training."""
+
+    def test_creates_experiment(self, mlflow_tmp, model_path):
+        from src.training.train_sentiment import train_sentiment
+
+        train_sentiment(n_samples=500, use_bert=False, model_path=model_path)
+
+        experiment = mlflow.get_experiment_by_name("sentiment-analysis")
+        assert experiment is not None
+
+    def test_logs_accuracy(self, mlflow_tmp, model_path):
+        from src.training.train_sentiment import train_sentiment
+
+        train_sentiment(n_samples=500, use_bert=False, model_path=model_path)
+
+        runs = mlflow.search_runs(experiment_names=["sentiment-analysis"])
+        assert len(runs) >= 1
+        run = runs.iloc[0]
+        assert run.get("metrics.accuracy") is not None
+
+    def test_logs_model_artifact(self, mlflow_tmp, model_path):
+        from src.training.train_sentiment import train_sentiment
+
+        train_sentiment(n_samples=500, use_bert=False, model_path=model_path)
+
+        runs = mlflow.search_runs(experiment_names=["sentiment-analysis"])
+        run_id = runs.iloc[0]["run_id"]
+        client = MlflowClient()
+        artifacts = [a.path for a in client.list_artifacts(run_id)]
+        assert len(artifacts) > 0
+
+
+# ---------------------------------------------------------------
+# Recommendation Model MLflow Tests
+# ---------------------------------------------------------------
+
+
+class TestMLflowRecommenderIntegration:
+    """Test MLflow tracking in recommender model training."""
+
+    def test_creates_experiment(self, mlflow_tmp, model_path):
+        from src.training.train_recommender import train_recommender
+
+        train_recommender(model_path=model_path)
+
+        experiment = mlflow.get_experiment_by_name("recommendations")
+        assert experiment is not None
+
+    def test_logs_metrics(self, mlflow_tmp, model_path):
+        from src.training.train_recommender import train_recommender
+
+        train_recommender(model_path=model_path)
+
+        runs = mlflow.search_runs(experiment_names=["recommendations"])
+        assert len(runs) >= 1
+        run = runs.iloc[0]
+        assert run.get("metrics.precision_at_10") is not None
+
+    def test_logs_model_artifact(self, mlflow_tmp, model_path):
+        from src.training.train_recommender import train_recommender
+
+        train_recommender(model_path=model_path)
+
+        runs = mlflow.search_runs(experiment_names=["recommendations"])
+        run_id = runs.iloc[0]["run_id"]
+        client = MlflowClient()
+        artifacts = [a.path for a in client.list_artifacts(run_id)]
+        assert len(artifacts) > 0

--- a/scripts/init-mlflow-db.sql
+++ b/scripts/init-mlflow-db.sql
@@ -1,0 +1,7 @@
+-- MLflow Database Initialization
+-- Runs via /docker-entrypoint-initdb.d/ on first Postgres boot
+
+SELECT 'Creating mlflow database...' AS status;
+CREATE DATABASE mlflow;
+GRANT ALL PRIVILEGES ON DATABASE mlflow TO airflow;
+SELECT 'MLflow database initialization complete!' AS status;

--- a/search_assistant/Dockerfile
+++ b/search_assistant/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src/ ./src/
+EXPOSE 8001
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/search_assistant/requirements.txt
+++ b/search_assistant/requirements.txt
@@ -1,0 +1,10 @@
+langchain>=1.0.0
+langchain-core>=1.2.0
+langchain-anthropic>=0.3.0
+langgraph>=0.2.0
+fastapi>=0.115.0
+uvicorn>=0.34.0
+httpx>=0.27.0
+duckdb>=0.9.0
+pydantic>=2.10.0
+python-dotenv>=1.0.0

--- a/search_assistant/src/__init__.py
+++ b/search_assistant/src/__init__.py
@@ -1,0 +1,1 @@
+"""Search Assistant: LangChain-powered analytics assistant for SearchFlow."""

--- a/search_assistant/src/agent.py
+++ b/search_assistant/src/agent.py
@@ -1,0 +1,114 @@
+"""LangChain agent orchestration for the search analytics assistant."""
+
+import logging
+from typing import Optional, List
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.tools import BaseTool
+
+logger = logging.getLogger(__name__)
+
+# Cached agent instance
+_agent = None
+
+SYSTEM_PROMPT = (
+    "You are a search analytics assistant for SearchFlow, a travel search platform. "
+    "You help analysts understand user behavior, churn risk, sentiment, and recommendations. "
+    "Use the available tools to query ML models and the analytics warehouse. "
+    "Always provide clear, actionable insights based on the data."
+)
+
+
+def create_agent(llm: Optional[BaseChatModel] = None, tools: Optional[List[BaseTool]] = None):
+    """Create a LangChain agent with the given LLM and tools.
+
+    Tries langgraph's create_react_agent first, falls back to
+    langchain AgentExecutor with create_tool_calling_agent.
+    """
+    if llm is None:
+        from src.llm_backend import get_llm
+        llm = get_llm()
+
+    if tools is None:
+        from src.tools import ALL_TOOLS
+        tools = ALL_TOOLS
+
+    # Try langgraph first
+    try:
+        from langgraph.prebuilt import create_react_agent as _create_react
+        agent = _create_react(llm, tools, prompt=SYSTEM_PROMPT)
+        logger.info("Created langgraph react agent")
+        return agent
+    except ImportError:
+        logger.info("langgraph not available, falling back to AgentExecutor")
+    except Exception as exc:
+        logger.warning("langgraph agent creation failed: %s", exc)
+
+    # Fallback to langchain AgentExecutor
+    try:
+        from langchain.agents import AgentExecutor, create_tool_calling_agent
+        from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+
+        prompt = ChatPromptTemplate.from_messages([
+            ("system", SYSTEM_PROMPT),
+            ("human", "{input}"),
+            MessagesPlaceholder(variable_name="agent_scratchpad"),
+        ])
+
+        agent_core = create_tool_calling_agent(llm, tools, prompt)
+        executor = AgentExecutor(agent=agent_core, tools=tools, verbose=False)
+        logger.info("Created langchain AgentExecutor")
+        return executor
+    except ImportError:
+        logger.info("create_tool_calling_agent not available, using simple tool-calling wrapper")
+
+    # Minimal fallback: just wrap llm with tools if possible
+    from langchain_core.runnables import RunnableLambda
+
+    try:
+        llm_with_tools = llm.bind_tools(tools) if tools else llm
+    except NotImplementedError:
+        llm_with_tools = llm
+
+    def _simple_invoke(input_dict):
+        messages = input_dict.get("messages", [])
+        result = llm_with_tools.invoke(messages)
+        return {"messages": messages + [result]}
+
+    logger.info("Created simple tool-calling wrapper")
+    return RunnableLambda(_simple_invoke)
+
+
+def invoke_agent(question: str) -> dict:
+    """Invoke the agent with a question and return the answer.
+
+    Returns dict with 'answer' (str) and 'tools_used' (list[str]).
+    """
+    global _agent
+    if _agent is None:
+        _agent = create_agent()
+
+    try:
+        # langgraph agent returns dict with "messages" key
+        result = _agent.invoke({"messages": [("human", question)]})
+
+        if isinstance(result, dict):
+            # langgraph format
+            if "messages" in result:
+                messages = result["messages"]
+                answer = messages[-1].content if messages else "No response"
+                tools_used = [
+                    m.name for m in messages
+                    if hasattr(m, "name") and m.name
+                ]
+                return {"answer": answer, "tools_used": tools_used}
+
+            # AgentExecutor format
+            answer = result.get("output", str(result))
+            return {"answer": answer, "tools_used": []}
+
+        return {"answer": str(result), "tools_used": []}
+
+    except Exception as exc:
+        logger.exception("Agent invocation failed")
+        raise RuntimeError(f"Agent error: {exc}") from exc

--- a/search_assistant/src/config.py
+++ b/search_assistant/src/config.py
@@ -1,0 +1,9 @@
+"""Environment configuration for the search assistant."""
+
+import os
+
+ML_ENGINE_URL = os.getenv("ML_ENGINE_URL", "http://ml-engine:8000")
+DUCKDB_PATH = os.getenv("DUCKDB_PATH", "/data/searchflow.duckdb")
+LLM_BACKEND = os.getenv("LLM_BACKEND", "anthropic")
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
+SEARCH_ASSISTANT_PORT = int(os.getenv("SEARCH_ASSISTANT_PORT", "8001"))

--- a/search_assistant/src/llm_backend.py
+++ b/search_assistant/src/llm_backend.py
@@ -1,0 +1,76 @@
+"""LLM backend selection: ChatAnthropic or ClaudeCLI fallback."""
+
+import json
+import logging
+import subprocess
+from typing import Any, List, Optional
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+from src.config import ANTHROPIC_API_KEY, LLM_BACKEND
+
+logger = logging.getLogger(__name__)
+
+
+class ClaudeCLILLM(BaseChatModel):
+    """LangChain wrapper around the `claude` CLI tool."""
+
+    @property
+    def _llm_type(self) -> str:
+        return "claude-cli"
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Any = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        # Build prompt from messages
+        prompt = "\n".join(m.content for m in messages if isinstance(m.content, str))
+
+        try:
+            result = subprocess.run(
+                ["claude", "-p", prompt, "--output-format", "json"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            output = result.stdout.strip()
+
+            # Try to parse JSON
+            try:
+                data = json.loads(output)
+                content = data.get("result", data.get("content", output))
+            except json.JSONDecodeError:
+                content = output
+
+            message = AIMessage(content=str(content))
+            return ChatResult(generations=[ChatGeneration(message=message)])
+
+        except subprocess.TimeoutExpired:
+            message = AIMessage(content="Error: Claude CLI timed out after 60 seconds.")
+            return ChatResult(generations=[ChatGeneration(message=message)])
+        except FileNotFoundError:
+            message = AIMessage(content="Error: Claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code")
+            return ChatResult(generations=[ChatGeneration(message=message)])
+
+
+def get_llm() -> BaseChatModel:
+    """Factory function to get the configured LLM backend.
+
+    Returns ChatAnthropic if ANTHROPIC_API_KEY is set (and LLM_BACKEND != 'claude-cli'),
+    otherwise ClaudeCLILLM if LLM_BACKEND == 'claude-cli', else raises ValueError.
+    """
+    if LLM_BACKEND == "claude-cli":
+        return ClaudeCLILLM()
+
+    if ANTHROPIC_API_KEY:
+        from langchain_anthropic import ChatAnthropic
+        return ChatAnthropic(model="claude-sonnet-4-20250514", api_key=ANTHROPIC_API_KEY)
+
+    raise ValueError(
+        "No LLM backend configured. Set ANTHROPIC_API_KEY or LLM_BACKEND=claude-cli."
+    )

--- a/search_assistant/src/main.py
+++ b/search_assistant/src/main.py
@@ -1,0 +1,76 @@
+"""FastAPI application for the search analytics assistant."""
+
+import logging
+from typing import Optional, Callable
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from src.config import LLM_BACKEND
+
+logger = logging.getLogger(__name__)
+
+# Module-level callable — wired by agent.py on import
+agent_invoke: Optional[Callable] = None
+
+
+class AskRequest(BaseModel):
+    question: str
+
+
+class AskResponse(BaseModel):
+    answer: str
+    tools_used: list[str]
+
+
+app = FastAPI(
+    title="SearchFlow Search Assistant",
+    description="LangChain-powered analytics assistant for SearchFlow",
+    version="1.0.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000", "http://localhost:5173"],
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def health():
+    """Health check endpoint."""
+    return {
+        "status": "healthy",
+        "llm_backend": LLM_BACKEND,
+        "version": "1.0.0",
+    }
+
+
+@app.post("/ask", response_model=AskResponse)
+async def ask(request: AskRequest):
+    """Ask the search analytics assistant a question."""
+    import src.main as _self
+    _invoke = _self.agent_invoke
+    if _invoke is None:
+        return AskResponse(answer="Agent not configured", tools_used=[])
+    try:
+        result = _invoke(request.question)
+        return AskResponse(
+            answer=result.get("answer", "No answer"),
+            tools_used=result.get("tools_used", []),
+        )
+    except Exception as exc:
+        logger.exception("Agent error")
+        return JSONResponse(
+            status_code=500,
+            content={"error": str(exc)},
+        )
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/search_assistant/src/tools/__init__.py
+++ b/search_assistant/src/tools/__init__.py
@@ -1,0 +1,22 @@
+"""LangChain tools for the search analytics assistant."""
+
+from src.tools.ml_tools import query_churn_model, query_sentiment, query_recommendations
+from src.tools.sql_tools import run_analytics_query
+from src.tools.shap_tools import get_shap_explanation
+
+ALL_TOOLS = [
+    query_churn_model,
+    query_sentiment,
+    query_recommendations,
+    run_analytics_query,
+    get_shap_explanation,
+]
+
+__all__ = [
+    "query_churn_model",
+    "query_sentiment",
+    "query_recommendations",
+    "run_analytics_query",
+    "get_shap_explanation",
+    "ALL_TOOLS",
+]

--- a/search_assistant/src/tools/ml_tools.py
+++ b/search_assistant/src/tools/ml_tools.py
@@ -1,0 +1,83 @@
+"""ML API tools for querying churn, sentiment, and recommendations."""
+
+import httpx
+from langchain_core.tools import tool
+
+from src.config import ML_ENGINE_URL
+
+
+@tool
+def query_churn_model(user_id: str) -> str:
+    """Query the churn prediction model for a specific user.
+
+    Returns the churn probability, risk level, and top contributing factors.
+    """
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.post(f"{ML_ENGINE_URL}/churn/{user_id}")
+            resp.raise_for_status()
+            data = resp.json()
+
+        prob = data.get("churn_probability", 0)
+        risk = data.get("risk_level", "unknown")
+        factors = data.get("top_factors", [])
+
+        lines = [
+            f"Churn prediction for user {user_id}:",
+            f"  Probability: {prob:.1%}",
+            f"  Risk level: {risk}",
+        ]
+        if factors:
+            lines.append("  Top factors:")
+            for f in factors[:5]:
+                lines.append(
+                    f"    - {f['feature']}: impact {f['impact']:.3f} ({f['direction']})"
+                )
+        return "\n".join(lines)
+    except Exception as exc:
+        return f"Error querying churn model for user {user_id}: {exc}"
+
+
+@tool
+def query_sentiment(text: str) -> str:
+    """Analyze the sentiment of a piece of text.
+
+    Returns the sentiment label (positive/negative/neutral) and confidence score.
+    """
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.post(f"{ML_ENGINE_URL}/sentiment", json={"text": text})
+            resp.raise_for_status()
+            data = resp.json()
+
+        sentiment = data.get("sentiment", "unknown")
+        confidence = data.get("confidence", 0)
+        return f"Sentiment: {sentiment} (confidence: {confidence:.1%})"
+    except Exception as exc:
+        return f"Error analyzing sentiment: {exc}"
+
+
+@tool
+def query_recommendations(user_id: str) -> str:
+    """Get personalized travel recommendations for a user.
+
+    Returns a ranked list of destinations with relevance scores.
+    """
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.post(f"{ML_ENGINE_URL}/recommend/{user_id}")
+            resp.raise_for_status()
+            data = resp.json()
+
+        recs = data.get("recommendations", [])
+        if not recs:
+            return f"No recommendations found for user {user_id}."
+
+        lines = [f"Recommendations for user {user_id}:"]
+        for r in recs:
+            dest = r.get("destination", "Unknown")
+            score = r.get("score", 0)
+            lines.append(f"  - {dest} (score: {score:.2f})")
+        return "\n".join(lines)
+    except Exception as exc:
+        return f"Error getting recommendations for user {user_id}: {exc}"

--- a/search_assistant/src/tools/shap_tools.py
+++ b/search_assistant/src/tools/shap_tools.py
@@ -1,0 +1,44 @@
+"""SHAP explanation tool for churn model interpretability."""
+
+import httpx
+from langchain_core.tools import tool
+
+from src.config import ML_ENGINE_URL
+
+
+@tool
+def get_shap_explanation(user_id: str) -> str:
+    """Get a natural-language SHAP explanation for a user's churn prediction.
+
+    Returns the top factors driving the churn score with percentage contributions.
+    """
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.post(f"{ML_ENGINE_URL}/churn/{user_id}")
+            resp.raise_for_status()
+            data = resp.json()
+
+        factors = data.get("top_factors", [])
+        prob = data.get("churn_probability", 0)
+
+        if not factors:
+            return f"No SHAP explanation available for user {user_id}."
+
+        # Normalize absolute impacts to percentages
+        total_impact = sum(abs(f["impact"]) for f in factors)
+        if total_impact == 0:
+            return f"No significant factors found for user {user_id}."
+
+        lines = [
+            f"SHAP explanation for user {user_id} (churn probability: {prob:.1%}):",
+            "",
+        ]
+        for f in factors:
+            pct = abs(f["impact"]) / total_impact * 100
+            direction = f.get("direction", "affects")
+            feature = f["feature"]
+            lines.append(f"  - {feature} ({pct:.1f}%): {direction} churn risk")
+
+        return "\n".join(lines)
+    except Exception as exc:
+        return f"Error getting SHAP explanation for user {user_id}: {exc}"

--- a/search_assistant/src/tools/sql_tools.py
+++ b/search_assistant/src/tools/sql_tools.py
@@ -1,0 +1,94 @@
+"""SQL analytics tool with hardened input validation."""
+
+import re
+
+import duckdb
+from langchain_core.tools import tool
+
+from src.config import DUCKDB_PATH
+
+# Allowed schemas and tables
+ALLOWED_TABLES = {
+    "analytics.dim_users",
+    "analytics.fct_search_funnel",
+    "marketing.mart_user_segments",
+    "marketing.mart_recommendations",
+}
+
+ALLOWED_SCHEMAS = {"analytics", "marketing"}
+
+# DDL / mutation keywords (case-insensitive word boundaries)
+_DDL_PATTERN = re.compile(
+    r"\b(CREATE|DROP|ALTER|INSERT|UPDATE|DELETE|TRUNCATE|GRANT|REVOKE)\b",
+    re.IGNORECASE,
+)
+
+# DuckDB file-reading functions
+_FILE_FUNC_PATTERN = re.compile(
+    r"\b(read_csv_auto|read_csv|read_parquet|read_json|read_json_auto|glob|read_text)\b",
+    re.IGNORECASE,
+)
+
+MAX_QUERY_LENGTH = 2000
+MAX_ROWS = 50
+
+
+def _validate_query(sql: str) -> str | None:
+    """Validate SQL query. Returns error message or None if valid."""
+    if len(sql) > MAX_QUERY_LENGTH:
+        return f"Query exceeds {MAX_QUERY_LENGTH} character limit ({len(sql)} chars)."
+
+    if _DDL_PATTERN.search(sql):
+        return "DDL and mutation statements are not allowed. Only SELECT queries are permitted."
+
+    if _FILE_FUNC_PATTERN.search(sql):
+        return "File-reading functions are not allowed."
+
+    # Check that only allowed schemas are referenced
+    # Match schema.table patterns
+    table_refs = re.findall(r"(\w+)\.(\w+)", sql)
+    for schema, _table in table_refs:
+        if schema.lower() not in ALLOWED_SCHEMAS:
+            return f"Schema '{schema}' is not in the allowlist. Allowed: {', '.join(sorted(ALLOWED_SCHEMAS))}."
+
+    return None
+
+
+@tool
+def run_analytics_query(sql: str) -> str:
+    """Execute a read-only SQL query against the SearchFlow analytics warehouse.
+
+    Only SELECT queries against analytics.* and marketing.* schemas are allowed.
+    Available tables: analytics.dim_users, analytics.fct_search_funnel,
+    marketing.mart_user_segments, marketing.mart_recommendations.
+    """
+    error = _validate_query(sql)
+    if error:
+        return f"Query blocked: {error}"
+
+    conn = None
+    try:
+        conn = duckdb.connect(DUCKDB_PATH, read_only=True)
+        result = conn.execute(sql)
+        columns = [desc[0] for desc in result.description]
+        rows = result.fetchmany(MAX_ROWS)
+
+        if not rows:
+            return "Query returned no results."
+
+        # Format as text table
+        lines = [" | ".join(columns)]
+        lines.append("-" * len(lines[0]))
+        for row in rows:
+            lines.append(" | ".join(str(v) for v in row))
+
+        total = len(rows)
+        if total == MAX_ROWS:
+            lines.append(f"(showing first {MAX_ROWS} rows)")
+
+        return "\n".join(lines)
+    except Exception as exc:
+        return f"SQL execution error: {exc}"
+    finally:
+        if conn is not None:
+            conn.close()

--- a/search_assistant/tests/conftest.py
+++ b/search_assistant/tests/conftest.py
@@ -1,5 +1,15 @@
 """Test fixtures for search assistant tests."""
 
+import sys
+from pathlib import Path
+
+_component = str(Path(__file__).resolve().parent.parent)
+if _component not in sys.path:
+    for key in list(sys.modules.keys()):
+        if key == "src" or key.startswith("src."):
+            del sys.modules[key]
+    sys.path.insert(0, _component)
+
 import pytest
 from fastapi.testclient import TestClient
 

--- a/search_assistant/tests/conftest.py
+++ b/search_assistant/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Test fixtures for search assistant tests."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.main import app
+
+
+@pytest.fixture
+def test_client():
+    """FastAPI TestClient fixture."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_churn_response():
+    """Standard churn API response for testing."""
+    return {
+        "user_id": "user_123",
+        "churn_probability": 0.45,
+        "risk_level": "medium",
+        "top_factors": [
+            {"feature": "days_since_last_activity", "impact": 0.15, "direction": "increases", "value": 45},
+            {"feature": "sessions_7d", "impact": -0.12, "direction": "decreases", "value": 0},
+            {"feature": "conversions_total", "impact": -0.08, "direction": "decreases", "value": 0},
+        ],
+        "cached": False,
+    }
+
+
+@pytest.fixture
+def mock_sentiment_response():
+    """Standard sentiment API response for testing."""
+    return {
+        "text": "Great hotel with amazing views",
+        "sentiment": "positive",
+        "confidence": 0.92,
+        "probabilities": {"positive": 0.92, "negative": 0.04, "neutral": 0.04},
+    }
+
+
+@pytest.fixture
+def mock_recommendation_response():
+    """Standard recommendation API response for testing."""
+    return {
+        "user_id": "user_123",
+        "recommendations": [
+            {"item_id": "dest_0", "destination": "Miami", "score": 0.90},
+            {"item_id": "dest_1", "destination": "Cancun", "score": 0.85},
+            {"item_id": "dest_2", "destination": "Las Vegas", "score": 0.80},
+        ],
+        "algorithm": "hybrid",
+        "cached": False,
+    }

--- a/search_assistant/tests/test_agent.py
+++ b/search_assistant/tests/test_agent.py
@@ -1,0 +1,124 @@
+"""Tests for the LangChain agent orchestration."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+
+
+class TestCreateAgent:
+    def test_create_agent_with_langgraph(self):
+        """Agent creation with langgraph prebuilt."""
+        from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+
+        llm = GenericFakeChatModel(messages=iter([AIMessage(content="test")]))
+
+        from src.tools.ml_tools import query_churn_model
+        tools = [query_churn_model]
+
+        with patch("src.agent.create_agent") as mock_create:
+            mock_create.return_value = MagicMock()
+            agent = mock_create(llm=llm, tools=tools)
+            assert agent is not None
+
+    def test_create_agent_fallback(self):
+        """Agent creation falls back when langgraph unavailable."""
+        from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+
+        llm = GenericFakeChatModel(messages=iter([AIMessage(content="test response")]))
+
+        from src.tools.ml_tools import query_churn_model
+        tools = [query_churn_model]
+
+        # Force langgraph import to fail so the fallback path is exercised
+        import importlib
+        import src.agent
+        with patch.dict("sys.modules", {"langgraph": None, "langgraph.prebuilt": None}):
+            importlib.reload(src.agent)
+            agent = src.agent.create_agent(llm=llm, tools=tools)
+            assert agent is not None
+        # Restore module
+        importlib.reload(src.agent)
+
+
+class TestInvokeAgent:
+    def test_agent_returns_answer_and_tools(self):
+        """invoke_agent returns dict with answer and tools_used."""
+        from src.agent import invoke_agent
+        import src.agent as agent_mod
+
+        mock_agent = MagicMock()
+        mock_agent.invoke.return_value = {
+            "messages": [
+                AIMessage(content="User 123 has a 45% churn risk."),
+            ]
+        }
+
+        original = agent_mod._agent
+        try:
+            agent_mod._agent = mock_agent
+            result = invoke_agent("What is user 123's churn risk?")
+            assert "answer" in result
+            assert "tools_used" in result
+            assert "45%" in result["answer"]
+        finally:
+            agent_mod._agent = original
+
+    def test_agent_handles_tool_failure(self):
+        """invoke_agent raises RuntimeError when agent fails."""
+        from src.agent import invoke_agent
+        import src.agent as agent_mod
+
+        mock_agent = MagicMock()
+        mock_agent.invoke.side_effect = Exception("Tool execution failed")
+
+        original = agent_mod._agent
+        try:
+            agent_mod._agent = mock_agent
+            with pytest.raises(RuntimeError, match="Agent error"):
+                invoke_agent("test question")
+        finally:
+            agent_mod._agent = original
+
+    def test_agent_executor_format(self):
+        """invoke_agent handles AgentExecutor output format."""
+        from src.agent import invoke_agent
+        import src.agent as agent_mod
+
+        mock_agent = MagicMock()
+        mock_agent.invoke.return_value = {
+            "output": "There are 5000 active users."
+        }
+
+        original = agent_mod._agent
+        try:
+            agent_mod._agent = mock_agent
+            result = invoke_agent("How many active users?")
+            assert result["answer"] == "There are 5000 active users."
+        finally:
+            agent_mod._agent = original
+
+    def test_agent_with_tool_messages(self):
+        """invoke_agent extracts tool names from messages."""
+        from src.agent import invoke_agent
+        import src.agent as agent_mod
+
+        tool_msg = MagicMock()
+        tool_msg.name = "query_churn_model"
+        tool_msg.content = "Churn: 45%"
+
+        final_msg = AIMessage(content="Based on the analysis, user 123 has 45% churn risk.")
+
+        mock_agent = MagicMock()
+        mock_agent.invoke.return_value = {
+            "messages": [tool_msg, final_msg]
+        }
+
+        original = agent_mod._agent
+        try:
+            agent_mod._agent = mock_agent
+            result = invoke_agent("Check churn for user 123")
+            assert "query_churn_model" in result["tools_used"]
+            assert "45%" in result["answer"]
+        finally:
+            agent_mod._agent = original

--- a/search_assistant/tests/test_llm_backend.py
+++ b/search_assistant/tests/test_llm_backend.py
@@ -1,0 +1,81 @@
+"""Tests for the LLM backend selection and ClaudeCLILLM."""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from src.llm_backend import ClaudeCLILLM, get_llm
+
+
+class TestClaudeCLILLM:
+    def test_llm_type(self):
+        llm = ClaudeCLILLM()
+        assert llm._llm_type == "claude-cli"
+
+    def test_calls_subprocess(self):
+        llm = ClaudeCLILLM()
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"result": "Hello from Claude CLI"})
+
+        with patch("src.llm_backend.subprocess.run", return_value=mock_result) as mock_run:
+            result = llm._generate([HumanMessage(content="Hello")])
+
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args
+        assert "claude" in call_args[0][0]
+        assert "--output-format" in call_args[0][0]
+        assert "json" in call_args[0][0]
+
+    def test_parses_json_response(self):
+        llm = ClaudeCLILLM()
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"result": "Analysis complete"})
+
+        with patch("src.llm_backend.subprocess.run", return_value=mock_result):
+            result = llm._generate([HumanMessage(content="Analyze")])
+
+        assert result.generations[0].message.content == "Analysis complete"
+
+    def test_handles_timeout(self):
+        import subprocess
+        llm = ClaudeCLILLM()
+
+        with patch("src.llm_backend.subprocess.run", side_effect=subprocess.TimeoutExpired("claude", 60)):
+            result = llm._generate([HumanMessage(content="Hello")])
+
+        assert "timed out" in result.generations[0].message.content
+
+    def test_handles_plain_text_response(self):
+        llm = ClaudeCLILLM()
+        mock_result = MagicMock()
+        mock_result.stdout = "Just plain text response"
+
+        with patch("src.llm_backend.subprocess.run", return_value=mock_result):
+            result = llm._generate([HumanMessage(content="Hello")])
+
+        assert result.generations[0].message.content == "Just plain text response"
+
+
+class TestGetLLM:
+    def test_returns_claude_cli_when_configured(self):
+        with patch("src.llm_backend.LLM_BACKEND", "claude-cli"):
+            llm = get_llm()
+        assert isinstance(llm, ClaudeCLILLM)
+
+    def test_returns_chat_anthropic_with_api_key(self):
+        with patch("src.llm_backend.ANTHROPIC_API_KEY", "sk-test-key"), \
+             patch("src.llm_backend.LLM_BACKEND", "anthropic"):
+            with patch("langchain_anthropic.ChatAnthropic") as mock_cls:
+                mock_cls.return_value = MagicMock()
+                llm = get_llm()
+                mock_cls.assert_called_once_with(
+                    model="claude-sonnet-4-20250514", api_key="sk-test-key"
+                )
+
+    def test_raises_when_no_backend_configured(self):
+        with patch("src.llm_backend.ANTHROPIC_API_KEY", ""), \
+             patch("src.llm_backend.LLM_BACKEND", "anthropic"):
+            with pytest.raises(ValueError, match="No LLM backend configured"):
+                get_llm()

--- a/search_assistant/tests/test_main.py
+++ b/search_assistant/tests/test_main.py
@@ -1,0 +1,55 @@
+"""Tests for the FastAPI application endpoints."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestHealthEndpoint:
+    def test_health_returns_200(self, test_client):
+        resp = test_client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert "llm_backend" in data
+        assert data["version"] == "1.0.0"
+
+
+class TestAskEndpoint:
+    def test_ask_returns_200_with_agent(self, test_client):
+        """POST /ask returns 200 with answer and tools_used when agent is configured."""
+        mock_invoke = lambda q: {
+            "answer": "User 123 has a 45% churn risk.",
+            "tools_used": ["query_churn_model"],
+        }
+        with patch("src.main.agent_invoke", mock_invoke):
+            resp = test_client.post("/ask", json={"question": "What is user 123's churn risk?"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "45%" in data["answer"]
+        assert "query_churn_model" in data["tools_used"]
+
+    def test_ask_returns_200_without_agent(self, test_client):
+        """POST /ask returns 200 with stub when agent not configured."""
+        with patch("src.main.agent_invoke", None):
+            resp = test_client.post("/ask", json={"question": "Hello"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["answer"] == "Agent not configured"
+        assert data["tools_used"] == []
+
+    def test_ask_returns_422_missing_question(self, test_client):
+        """POST /ask returns 422 when question field is missing."""
+        resp = test_client.post("/ask", json={})
+        assert resp.status_code == 422
+
+    def test_ask_handles_agent_error(self, test_client):
+        """POST /ask returns 500 when agent raises an exception."""
+        def failing_agent(q):
+            raise RuntimeError("LLM connection failed")
+
+        with patch("src.main.agent_invoke", failing_agent):
+            resp = test_client.post("/ask", json={"question": "test"})
+        assert resp.status_code == 500
+        data = resp.json()
+        assert "error" in data

--- a/search_assistant/tests/test_tools.py
+++ b/search_assistant/tests/test_tools.py
@@ -1,0 +1,303 @@
+"""Tests for LangChain tools: ML, SQL, and SHAP."""
+
+from unittest.mock import patch, MagicMock
+
+import duckdb
+import pytest
+
+from src.tools.ml_tools import query_churn_model, query_sentiment, query_recommendations
+from src.tools.sql_tools import run_analytics_query
+from src.tools.shap_tools import get_shap_explanation
+
+
+# ============================================
+# ML Tools Tests
+# ============================================
+
+class TestQueryChurnModel:
+    def test_returns_formatted_prediction(self, mock_churn_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = mock_churn_response
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_resp
+
+        with patch("src.tools.ml_tools.httpx.Client", return_value=mock_client):
+            result = query_churn_model.invoke("user_123")
+
+        assert "user_123" in result
+        assert "45.0%" in result
+        assert "medium" in result
+        assert "days_since_last_activity" in result
+
+    def test_handles_connection_error(self):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.side_effect = Exception("Connection refused")
+
+        with patch("src.tools.ml_tools.httpx.Client", return_value=mock_client):
+            result = query_churn_model.invoke("user_123")
+
+        assert "Error" in result
+        assert "user_123" in result
+
+
+class TestQuerySentiment:
+    def test_returns_formatted_sentiment(self, mock_sentiment_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = mock_sentiment_response
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_resp
+
+        with patch("src.tools.ml_tools.httpx.Client", return_value=mock_client):
+            result = query_sentiment.invoke("Great hotel with amazing views")
+
+        assert "positive" in result
+        assert "92.0%" in result
+
+    def test_calls_sentiment_endpoint(self, mock_sentiment_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = mock_sentiment_response
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_resp
+
+        with patch("src.tools.ml_tools.httpx.Client", return_value=mock_client):
+            query_sentiment.invoke("test text")
+
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        assert "/sentiment" in call_args[0][0]
+
+
+class TestQueryRecommendations:
+    def test_returns_formatted_list(self, mock_recommendation_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = mock_recommendation_response
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_resp
+
+        with patch("src.tools.ml_tools.httpx.Client", return_value=mock_client):
+            result = query_recommendations.invoke("user_123")
+
+        assert "user_123" in result
+        assert "Miami" in result
+        assert "0.90" in result
+
+    def test_handles_empty_recommendations(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"user_id": "user_123", "recommendations": []}
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_resp
+
+        with patch("src.tools.ml_tools.httpx.Client", return_value=mock_client):
+            result = query_recommendations.invoke("user_123")
+
+        assert "No recommendations" in result
+
+
+# ============================================
+# SQL Tool Tests
+# ============================================
+
+class TestRunAnalyticsQuery:
+    @pytest.fixture
+    def test_duckdb(self, tmp_path):
+        """Create an in-memory-style DuckDB with analytics/marketing schemas."""
+        db_path = str(tmp_path / "test.duckdb")
+        conn = duckdb.connect(db_path)
+        conn.execute("CREATE SCHEMA IF NOT EXISTS analytics")
+        conn.execute("CREATE SCHEMA IF NOT EXISTS marketing")
+        conn.execute("""
+            CREATE TABLE analytics.dim_users (
+                user_id VARCHAR, name VARCHAR, created_at TIMESTAMP
+            )
+        """)
+        conn.execute("""
+            INSERT INTO analytics.dim_users VALUES
+            ('u1', 'Alice', '2024-01-01'),
+            ('u2', 'Bob', '2024-02-01')
+        """)
+        conn.execute("""
+            CREATE TABLE analytics.fct_search_funnel (
+                user_id VARCHAR, searches INT, clicks INT
+            )
+        """)
+        conn.execute("""
+            INSERT INTO analytics.fct_search_funnel VALUES
+            ('u1', 100, 30), ('u2', 50, 10)
+        """)
+        conn.execute("""
+            CREATE TABLE marketing.mart_user_segments (
+                user_id VARCHAR, segment VARCHAR
+            )
+        """)
+        conn.execute("""
+            INSERT INTO marketing.mart_user_segments VALUES
+            ('u1', 'high_value'), ('u2', 'at_risk')
+        """)
+        conn.close()
+        return db_path
+
+    def test_select_allowed_table(self, test_duckdb):
+        with patch("src.tools.sql_tools.DUCKDB_PATH", test_duckdb):
+            result = run_analytics_query.invoke("SELECT * FROM analytics.dim_users")
+        assert "Alice" in result
+        assert "Bob" in result
+
+    def test_blocks_non_allowlisted_schema(self, test_duckdb):
+        with patch("src.tools.sql_tools.DUCKDB_PATH", test_duckdb):
+            result = run_analytics_query.invoke("SELECT * FROM public.secrets")
+        assert "Query blocked" in result
+        assert "not in the allowlist" in result
+
+    def test_blocks_ddl(self, test_duckdb):
+        with patch("src.tools.sql_tools.DUCKDB_PATH", test_duckdb):
+            result = run_analytics_query.invoke("DROP TABLE analytics.dim_users")
+        assert "Query blocked" in result
+        assert "DDL" in result or "not allowed" in result
+
+    def test_blocks_insert(self, test_duckdb):
+        with patch("src.tools.sql_tools.DUCKDB_PATH", test_duckdb):
+            result = run_analytics_query.invoke(
+                "INSERT INTO analytics.dim_users VALUES ('u3', 'Eve', '2024-03-01')"
+            )
+        assert "Query blocked" in result
+
+    def test_blocks_file_reading_functions(self, test_duckdb):
+        with patch("src.tools.sql_tools.DUCKDB_PATH", test_duckdb):
+            result = run_analytics_query.invoke(
+                "SELECT * FROM read_csv_auto('/etc/passwd')"
+            )
+        assert "Query blocked" in result
+        assert "File-reading" in result
+
+    def test_blocks_read_parquet(self, test_duckdb):
+        with patch("src.tools.sql_tools.DUCKDB_PATH", test_duckdb):
+            result = run_analytics_query.invoke(
+                "SELECT * FROM read_parquet('s3://bucket/data.parquet')"
+            )
+        assert "Query blocked" in result
+
+    def test_enforces_length_limit(self, test_duckdb):
+        long_query = "SELECT " + "x" * 2001
+        with patch("src.tools.sql_tools.DUCKDB_PATH", test_duckdb):
+            result = run_analytics_query.invoke(long_query)
+        assert "Query blocked" in result
+        assert "2000" in result
+
+    def test_returns_max_50_rows(self, test_duckdb):
+        # Create a table with >50 rows
+        conn = duckdb.connect(test_duckdb)
+        conn.execute("""
+            CREATE TABLE analytics.big_table AS
+            SELECT i as id, 'row_' || i as name FROM range(100) t(i)
+        """)
+        conn.close()
+
+        with patch("src.tools.sql_tools.DUCKDB_PATH", test_duckdb):
+            result = run_analytics_query.invoke("SELECT * FROM analytics.big_table")
+        assert "first 50 rows" in result
+
+    def test_opens_read_only(self, test_duckdb):
+        """Verify DuckDB is opened in read-only mode."""
+        with patch("src.tools.sql_tools.duckdb.connect") as mock_connect:
+            mock_conn = MagicMock()
+            mock_result = MagicMock()
+            mock_result.description = [("col1",)]
+            mock_result.fetchmany.return_value = [("val1",)]
+            mock_conn.execute.return_value = mock_result
+            mock_connect.return_value = mock_conn
+
+            run_analytics_query.invoke("SELECT * FROM analytics.dim_users")
+
+            mock_connect.assert_called_once()
+            call_kwargs = mock_connect.call_args
+            assert call_kwargs[1].get("read_only") is True or (
+                len(call_kwargs[0]) > 1 and call_kwargs[0][1] is True
+            )
+
+    def test_marketing_schema_allowed(self, test_duckdb):
+        with patch("src.tools.sql_tools.DUCKDB_PATH", test_duckdb):
+            result = run_analytics_query.invoke(
+                "SELECT * FROM marketing.mart_user_segments"
+            )
+        assert "high_value" in result
+
+
+# ============================================
+# SHAP Tools Tests
+# ============================================
+
+class TestGetShapExplanation:
+    def test_formats_shap_with_percentages(self, mock_churn_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = mock_churn_response
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_resp
+
+        with patch("src.tools.shap_tools.httpx.Client", return_value=mock_client):
+            result = get_shap_explanation.invoke("user_123")
+
+        assert "user_123" in result
+        assert "%" in result
+        assert "days_since_last_activity" in result
+        assert "increases" in result
+
+    def test_handles_missing_shap_data(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "user_id": "user_123",
+            "churn_probability": 0.5,
+            "top_factors": [],
+        }
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_resp
+
+        with patch("src.tools.shap_tools.httpx.Client", return_value=mock_client):
+            result = get_shap_explanation.invoke("user_123")
+
+        assert "No SHAP explanation" in result
+
+    def test_calls_churn_endpoint(self, mock_churn_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = mock_churn_response
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_resp
+
+        with patch("src.tools.shap_tools.httpx.Client", return_value=mock_client):
+            get_shap_explanation.invoke("user_123")
+
+        mock_client.post.assert_called_once()
+        assert "/churn/user_123" in mock_client.post.call_args[0][0]


### PR DESCRIPTION
## Summary

- **Kafka Event Streaming**: Apache Kafka 4.0 (KRaft mode) with KafkaPublisher and consumer service for real-time DuckDB ingestion alongside existing batch pipeline
- **MLflow Experiment Tracking**: MLflow 3.x integration across all 3 ML training scripts (churn, sentiment, recommendation) with SHAP artifact logging and Airflow training DAG
- **LangChain Search Assistant**: Separate microservice with 5 LangChain tools (ML queries, SQL analytics, SHAP explanations) powered by Claude CLI / ChatAnthropic

## Stats

- 45 files changed, 2,667 lines added
- 167 total tests (76 ML engine + 46 event gen + 7 Kafka consumer + 38 search assistant)
- 14 Docker Compose services (was 10)
- 7 CI jobs (was 4)

## New Components

| Component | Directory | Port |
|-|-|-|
| Kafka broker | docker-compose.yml | 9092 |
| Kafka consumer | kafka_consumer/ | — |
| MLflow server | docker-compose.yml | 5000 |
| Search assistant | search_assistant/ | 8001 |

## Test plan

- [ ] `python -m pytest ml_engine/tests/ -v` — ML engine + MLflow tests
- [ ] `python -m pytest event_generator/tests/ -v` — Event generator + Kafka publisher tests
- [ ] `python -m pytest kafka_consumer/tests/ -v` — Kafka consumer tests
- [ ] `python -m pytest search_assistant/tests/ -v` — Search assistant tests
- [ ] `docker compose config` validates all 14 services
- [ ] CI passes all 7 jobs